### PR TITLE
Update Examples So They Compile (mac)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,4 @@ before_install:
 
 script:
   - make
+  - make examples

--- a/examples/dev_gui_clock_widget.cpp
+++ b/examples/dev_gui_clock_widget.cpp
@@ -90,7 +90,7 @@ void draw_clock(float x, float y, float radius=100, float opacity=1.0)
 
    al_draw_filled_circle(x, y, scale*1.5, color::name("black", opacity));
 
-   if (true)
+   if (false)
    {
       ALLEGRO_BITMAP *clock_overlay = Framework::bitmap("clock_overlay.png");
       float clock_overlay_scale = scale/2;
@@ -112,7 +112,7 @@ void hide_clock(void *obj, ALLEGRO_MOUSE_EVENT *ev, void *user)
 {
    Framework::motion().cmove_to(&clock_opacity, 0.0, 0.6);
    Framework::motion().cmove_to(&clock_radius, max_clock_radius*0.9, 0.6);
-   if (clock_opacity == 1.0) al_play_sample(Framework::sample("clock_hide.wav"), 1.0, 0.0, 1.0, ALLEGRO_PLAYMODE_ONCE, NULL);
+   //if (clock_opacity == 1.0) al_play_sample(Framework::sample("clock_hide.wav"), 1.0, 0.0, 1.0, ALLEGRO_PLAYMODE_ONCE, NULL);
 }
 
 
@@ -122,7 +122,7 @@ void show_clock(void *obj, ALLEGRO_MOUSE_EVENT *ev, void *user)
 {
    Framework::motion().cmove_to(&clock_opacity, 1.0, 0.3, interpolator::slow_in_out);
    Framework::motion().cmove_to(&clock_radius, max_clock_radius, 0.3, interpolator::slow_in_out);
-   if (clock_opacity == 0.0) al_play_sample(Framework::sample("clock_show.wav"), 1.0, 0.0, 1.0, ALLEGRO_PLAYMODE_ONCE, NULL);
+   //if (clock_opacity == 0.0) al_play_sample(Framework::sample("clock_show.wav"), 1.0, 0.0, 1.0, ALLEGRO_PLAYMODE_ONCE, NULL);
 }
 
 

--- a/examples/dev_gui_console.cpp
+++ b/examples/dev_gui_console.cpp
@@ -12,6 +12,23 @@
 
 // come back to this, Mark, this is a cool idea.
 
+class IgnoreBackquoteTextInput : public UITextInput
+{
+private:
+   int toggle_key;
+
+public:
+   IgnoreBackquoteTextInput(UIWidget *parent, float x, float y, float w, float h, std::string initial_text="")
+      : UITextInput(parent, x, y, w, h, initial_text)
+      , toggle_key(ALLEGRO_KEY_BACKQUOTE)
+   {}
+   void on_key_char() override
+   {
+      if (Framework::current_event->keyboard.keycode == toggle_key) return;
+      UITextInput::on_key_char();
+   }
+};
+
 
 
 
@@ -60,21 +77,21 @@ public:
    float console_height;
    float text_input_height;
    int current_indexed_past_message;
-   UITextInput *text_input_widget;
+   IgnoreBackquoteTextInput *text_input_widget;
 
    UIConsole(Display *display)
       : UIScreen(display)
       , font(Framework::font("DroidSans.ttf 19"))
       , active(false)
       , visibility_counter(0)
-      , toggle_key(ALLEGRO_KEY_TILDE)
+      , toggle_key(ALLEGRO_KEY_BACKQUOTE)
       , console_height(200)
       , text_input_widget(NULL)
       , text_input_height(al_get_font_line_height(font)*2)
       , console_padding(20)
       , current_indexed_past_message(0)
    {
-      text_input_widget = new UITextInput(this, console_padding, -150, display->width()-console_padding*2, text_input_height, "");
+      text_input_widget = new IgnoreBackquoteTextInput(this, console_padding, -150, display->width()-console_padding*2, text_input_height, "");
       text_input_widget->place.align.x = 0.0;
       text_input_widget->place.align.y = 1.0;
    }
@@ -111,7 +128,7 @@ public:
 
    void on_draw() override
    {
-      al_draw_filled_rectangle(0, 0, display->width(), console_height * visibility_counter, color::darkblue);
+      al_draw_filled_rectangle(0, 0, display->width(), console_height * visibility_counter, color::hex("#303030"));
 
       if (!active) return;
 
@@ -170,10 +187,6 @@ public:
       , console(NULL)
    {
       console = new UIConsole(display);
-   }
-   void mouse_down_func() override
-   {
-      console->toggle_visibility();
    }
 };
 

--- a/examples/dev_gui_console.cpp
+++ b/examples/dev_gui_console.cpp
@@ -2,9 +2,10 @@
 
 
 
-#include <allegro_flare/gui/gui_screen.h>
-#include <allegro_flare/gui/widgets/text_input.h>
+#include <allegro_flare/gui_screen.h>
+#include <allegro_flare/text_input.h>
 #include <allegro_flare/framework.h>
+#include <AllegroFlare/UsefulPHP.hpp>
 
 
 

--- a/examples/dev_gui_notification_bubble.cpp
+++ b/examples/dev_gui_notification_bubble.cpp
@@ -5,9 +5,9 @@
 
 
 #include <allegro_flare/allegro_flare.h>
-#include <allegro_flare/color.h>
-#include <allegro_flare/gui/widget.h>
-#include <allegro_flare/gui/surface_areas/box.h>
+#include <AllegroFlare/Color.hpp>
+#include <allegro_flare/widget.h>
+#include <allegro_flare/box.h>
 
 #include <allegro5/allegro_font.h>
 #include <allegro5/allegro_primitives.h>

--- a/examples/dev_transition_fx.cpp
+++ b/examples/dev_transition_fx.cpp
@@ -40,7 +40,7 @@ namespace TransitionFX
 
 //#include <models/transition_fx/base.hpp>
 
-#include <allegro_flare/color.h>
+#include <AllegroFlare/Color.hpp>
 
 
 namespace TransitionFX

--- a/examples/ex_gamer_input.cpp
+++ b/examples/ex_gamer_input.cpp
@@ -17,8 +17,8 @@
 
 
 #include <allegro_flare/allegro_flare.h>
-#include <allegro_flare/screens/gamer_input_screen.h>
-#include <allegro_flare/screens/simple_notification_screen.h>
+#include <allegro_flare/gamer_input_screen.h>
+#include <allegro_flare/simple_notification_screen.h>
 
 
 

--- a/examples/ex_gui.cpp
+++ b/examples/ex_gui.cpp
@@ -4,6 +4,8 @@
 
 #include <allegro_flare/allegro_flare.h>
 
+#include <AllegroFlare/UsefulPHP.hpp>
+
 
 
 
@@ -341,7 +343,7 @@ int main(int argc, char *argv[])
    Display *display = new Display(800, 720, ALLEGRO_NOFRAME);
    al_register_event_source(Framework::event_queue, al_get_display_event_source(display->al_display));
 
-   ExGUI *main = new ExGUI(display);
+   ExGUI *ex_gui = new ExGUI(display);
    Framework::run_loop();
 
    return 0;

--- a/examples/ex_gui_color_picker.cpp
+++ b/examples/ex_gui_color_picker.cpp
@@ -8,7 +8,7 @@
 
 
 #include <math.h>
-#include <allegro_flare/gui/surface_areas/box.h>
+#include <allegro_flare/box.h>
 
 
 

--- a/examples/ex_gui_function_parser.cpp
+++ b/examples/ex_gui_function_parser.cpp
@@ -4,6 +4,8 @@
 
 #include <allegro_flare/allegro_flare.h>
 
+#include <AllegroFlare/UsefulPHP.hpp>
+
 
 
 

--- a/examples/ex_gui_keyboard_joystick_modes.cpp
+++ b/examples/ex_gui_keyboard_joystick_modes.cpp
@@ -3,7 +3,7 @@
 
 
 #include <allegro_flare/allegro_flare.h>
-#include <allegro_flare/screens/simple_notification_screen.h>
+#include <allegro_flare/simple_notification_screen.h>
 
 //using namespace UIGlobal;
 

--- a/examples/ex_gui_music_calculator.cpp
+++ b/examples/ex_gui_music_calculator.cpp
@@ -11,6 +11,8 @@
 #include <stdio.h>
 #include <string>
 
+#include <AllegroFlare/UsefulPHP.hpp>
+
 
 
 
@@ -73,8 +75,8 @@ RubyScriptResult run_ruby_script(std::string script_filename, std::string args)
 
 
 #include <allegro_flare/allegro_flare.h>
-#include <allegro_flare/gui/widgets/music_notation.h>
-#include <allegro_flare/drawing_interfaces/drawing_interface_allegro5.h>
+#include <allegro_flare/music_notation.h>
+#include <allegro_flare/drawing_interface_allegro5.h>
 
 #include <algorithm>
 

--- a/examples/ex_gui_picking_buffer.cpp
+++ b/examples/ex_gui_picking_buffer.cpp
@@ -4,6 +4,8 @@
 
 #include <allegro_flare/allegro_flare.h>
 
+#include <allegro_flare/ui_picking_buffer.h>
+
 
 
 

--- a/examples/ex_gui_skeleton.cpp
+++ b/examples/ex_gui_skeleton.cpp
@@ -4,7 +4,7 @@
 
 #include <allegro_flare/allegro_flare.h>
 #include <allegro_flare/skeleton.h>
-#include <allegro_flare/screens/simple_notification_screen.h>
+#include <allegro_flare/simple_notification_screen.h>
 
 
 

--- a/examples/ex_gui_tool_layout_loader.cpp
+++ b/examples/ex_gui_tool_layout_loader.cpp
@@ -4,7 +4,8 @@
 
 #include <allegro_flare/allegro_flare.h>
 
-#include <allegro_flare/gui/layout_loaders/gui_tool_layout_loader.h>
+#include <allegro_flare/gui_tool_layout_loader.h>
+#include <AllegroFlare/UsefulPHP.hpp>
 
 
 

--- a/examples/ex_music_notation.cpp
+++ b/examples/ex_music_notation.cpp
@@ -4,7 +4,7 @@
 
 #include <allegro_flare/allegro_flare.h>
 
-#include <allegro_flare/drawing_interfaces/drawing_interface_allegro5.h>
+#include <allegro_flare/drawing_interface_allegro5.h>
 
 
 

--- a/examples/ex_ray_casting.cpp
+++ b/examples/ex_ray_casting.cpp
@@ -13,6 +13,8 @@
 
 #include <allegro_flare/allegro_flare.h>
 
+#include <AllegroFlare/UsefulPHP.hpp>
+
 
 
 
@@ -766,9 +768,11 @@ public:
    std::vector<StrippedTexture *> textures;
 
    TextureBank()
-      : bitmaps("data/raycast_demo/bitmaps")
+      : bitmaps()
       , textures()
-   {}
+   {
+      bitmaps.set_path("data/raycast_demo/bitmaps");
+   }
 
    bool load_texture(int index, std::string filename)
    {
@@ -1198,9 +1202,9 @@ public:
       , viewport_height((int)(viewport_width * (float)display->height()/display->width()-frame_width + 100))
       , viewport_render(al_create_bitmap(viewport_width, viewport_height))
       , viewport(viewport_render)
-      , bitmaps("data/raycast_demo/bitmaps")
+      , bitmaps()
       , player_num_card_keys(0)
-      , samples("data/raycast_demo/samples")
+      , samples()
       , debug(false)
       , motion(50)
       , gun_flash_a(bitmaps["gun_flash_a.png"])
@@ -1209,6 +1213,10 @@ public:
       , magazine_capacity(8)
       , bullets_in_magazine(magazine_capacity)
    {
+      bitmaps.set_path("data/raycast_demo/bitmaps");
+      samples.set_path("data/raycast_demo/samples");
+
+
       direction = vec2d(-1, 0);
       dirX = -1;
       dirY = 0;

--- a/examples/ex_unicode_font_viewer.cpp
+++ b/examples/ex_unicode_font_viewer.cpp
@@ -5,7 +5,7 @@
 #include <allegro_flare/allegro_flare.h>
 #include <allegro_flare/screen.h>
 #include <allegro5/allegro_font.h>
-#include <allegro_flare/bins/font_bin.h>
+#include <AllegroFlare/FontBin.hpp>
 
 
 
@@ -32,12 +32,17 @@ public:
 
 UnicodeFontViewerExample::UnicodeFontViewerExample(Display *display, std::string font_identifier_str)
    : Screen(display)
-   , fonts("data/fonts")
+   , fonts()
    , unicode_font(fonts[font_identifier_str])
-   , ui_font(fonts["DroidSans.ttf 20"])
-   , ui_font_mini(fonts["DroidSans.ttf 9"])
+   , ui_font(nullptr)
+   , ui_font_mini(nullptr)
    , unicode_range_start(0x1D000)
-{}
+{
+   fonts.set_path("data/fonts");
+
+   ui_font = fonts["DroidSans.ttf 20"];
+   ui_font_mini = fonts["DroidSans.ttf 9"];
+}
 
 
 

--- a/src/allegro_flare/sample_renderer.cpp
+++ b/src/allegro_flare/sample_renderer.cpp
@@ -1,0 +1,170 @@
+
+
+
+
+#include <allegro_flare/sample_renderer.h>
+
+#include <iostream>
+#include <allegro5/allegro_acodec.h>
+#include <allegro5/allegro_color.h>
+#include <allegro5/allegro_primitives.h>
+
+
+
+
+SampleRenderer::SampleRenderer(ALLEGRO_SAMPLE *sample)
+   : sample(sample)
+   , composite_stereo_render(true)
+{
+}
+
+
+
+
+SampleRenderer::~SampleRenderer()
+{
+}
+
+
+
+
+// This function returns a positive value between 0 and 1 of the maximum value between the given ranges.
+// Note that samples are normally in positive and negative values, this will return the max abs value.
+// This function is not sample-acurate, but will return usable approximate results.
+float SampleRenderer::get_max_f_sample_within(float pos_begin, float pos_end, int channel_num)
+{
+   if (!sample || (pos_end<0) || (pos_begin >= al_get_sample_length(sample))) return 0;
+
+   short *short_pointer = NULL;
+   char *char_pointer = NULL;
+
+   int sample_val = 0;
+   int val;
+
+   switch(al_get_sample_depth(sample))
+   {
+   case ALLEGRO_AUDIO_DEPTH_INT16:
+      short_pointer = (short *)al_get_sample_data(sample);
+      for (int i=pos_begin; i<pos_end; i++)
+      {
+         val = abs(short_pointer[i*2+channel_num]);
+         if (val > sample_val) sample_val = val;
+      }
+      return sample_val / (float)32768 * 2;
+      break;
+   case ALLEGRO_AUDIO_DEPTH_INT8:
+      char_pointer = (char *)al_get_sample_data(sample);
+      for (int i=pos_begin; i<pos_end; i++)
+      {
+         val = abs(char_pointer[i*2+channel_num]);
+         if (val > sample_val) sample_val = val;
+      }
+      return sample_val / (float)128 * 2;
+      break;
+   default:
+      break;
+   }
+
+   return 0;
+}
+
+
+
+
+void SampleRenderer::draw_wav_sample(ALLEGRO_BITMAP *dest)
+{
+   if (!sample) return;
+   draw_wav_sample(dest, 0, al_get_sample_length(sample));
+}
+
+
+
+
+void SampleRenderer::draw_wav_sample(ALLEGRO_BITMAP *dest, float samp_start, float samp_end)
+{
+   if (!dest) { std::cout << "(!) Could not render sample: destination bitmap is invalid." << std::endl; return; }
+   ALLEGRO_BITMAP *prev = al_get_target_bitmap();
+   al_set_target_bitmap(dest);
+   al_clear_to_color(al_color_name("black"));
+
+   draw_wav_sample(1, 1, al_get_bitmap_width(dest)-1, al_get_bitmap_height(dest)-2, samp_start, samp_end);
+
+   al_set_target_bitmap(prev);
+}
+
+
+
+
+void SampleRenderer::draw_wav_sample(float x, float y, float width, float height, float samp_start, float samp_end)
+{
+   if (!sample) return;
+
+   float center_y = y+height*0.5f;
+   float half_h = height*0.5f;
+
+   //al_draw_rectangle(x, y, x+width, y+height, al_color_name("orange"), 1.0f);
+   if (composite_stereo_render)
+   {
+      al_draw_line(x, center_y, x+width, center_y, al_color_name("lightgreen"), 1.0f);
+   }
+   else
+   {
+      al_draw_line(x, center_y-half_h/2, x+width, center_y-half_h/2, al_color_name("lightgreen"), 1.0f);
+      al_draw_line(x, center_y+half_h/2, x+width, center_y+half_h/2, al_color_name("lightgreen"), 1.0f);
+   }
+
+   //float scale = 0.05f;
+
+   float num_samples_in_range = (samp_end - samp_start);
+
+   al_set_blender(ALLEGRO_ADD, ALLEGRO_ONE, ALLEGRO_ONE);
+   //al_set_blender();
+
+   ALLEGRO_COLOR color = al_color_name("lightblue");
+   float alpha = 0.04;
+   if (composite_stereo_render) alpha = 0.02;
+   color.r *= alpha;
+   color.g *= alpha;
+   color.b *= alpha;
+   color.a *= alpha;
+
+   ALLEGRO_COLOR left_channel = color;
+   ALLEGRO_COLOR right_channel = color;
+
+   float x_pos=0;
+   float left_sample_y = 0;
+   float left_center_y = -half_h/2;
+   float right_sample_y = 0;
+   float right_center_y = half_h/2;
+   float signal_half_scale = half_h*0.25f;
+
+   if (composite_stereo_render)
+   {
+      left_center_y = right_center_y = 0;
+      signal_half_scale *= 2;
+   }
+
+   x+=0.5f;
+   float x_pos_increment = 0.01;
+   // if this function strangely crashes, change the x_pos_increment to 1.0;
+   //x_pos_increment = 1.0;
+   for (; x_pos<=width; x_pos+=x_pos_increment)
+   {
+      //float target_sample = x_pos / width * num_samples_in_range + samp_start;
+      float target_sample_start = x_pos / width * num_samples_in_range + samp_start;
+      float target_sample_end = (x_pos+x_pos_increment) / width * num_samples_in_range + samp_start;
+
+      //left_sample_y = get_f_sample_at(sample, target_sample, 0) * signal_half_scale;
+      left_sample_y = get_max_f_sample_within(target_sample_start, target_sample_end, 0) * signal_half_scale;
+      al_draw_line(x+x_pos, center_y-left_sample_y+left_center_y, x+x_pos, center_y+left_sample_y+left_center_y, left_channel, 0.5f);
+
+      //right_sample_y = get_f_sample_at(sample, target_sample, 1) * signal_half_scale;
+      right_sample_y = get_max_f_sample_within(target_sample_start, target_sample_end, 1) * signal_half_scale;
+      al_draw_line(x+x_pos, center_y-right_sample_y+right_center_y, x+x_pos, center_y+right_sample_y+right_center_y, right_channel, 0.5f);
+   }
+
+   al_set_blender(ALLEGRO_ADD, ALLEGRO_ONE, ALLEGRO_INVERSE_ALPHA);
+}
+
+
+


### PR DESCRIPTION
## Problem

Most example files do not build since https://github.com/allegroflare/allegro_flare/pull/153.

## Solution

This PR updates the example programs to at least build now with the different folder structure.  

## Note

* Some of the examples are crashing and I did not run them all to see if they worked, but that's a different issue.  I tweaked an example program or two here in the PR, but it was outside the scope of this PR so I stopped before doing too many.

* Included in this PR is the very peculiar mystery of a missing `src/allegro_flare/sample_renderer.cpp` file.  It looks like it was accidentally removed in https://github.com/allegroflare/allegro_flare/pull/153 and that was added back in here, too.

* There are some example program files that are in sub folders.  Some of these have special build needs with dependencies, so I will not address that here in this PR.  (They, for one reason or another, are not included for build during `make examples`, so that will have to be solved another time, too.)

* `make examples` is added to the `.travis.yml` build script.

* Builds are still failing on Linux regardless of the state of examples.  For that reason, it's not a priority in this PR to anticipate or predict how `make examples` will affect the Linux build.