### PR TITLE
Include GoogleTest in Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,13 @@ before_install:
          brew install opusfile libvorbis freetype flac physfs;
          brew install allegro;
          brew install boost;
+         git clone https://github.com/google/googletest
+         cd googletest
+         mkdir build
+         cd build
+         cmake ..
+         make
+         make install
       fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,17 @@ compiler:
   - gcc
 
 before_install:
+    - if [ `uname` = "Darwin" ]; then
+         git clone https://github.com/google/googletest;
+         cd googletest;
+         mkdir build;
+         cd build;
+         cmake ..;
+         make;
+         make install;
+         cd ..;
+         cd ..;
+      fi
     - if [ `uname` = "Linux" ]; then
          sudo apt-get update;
          sudo apt-get install -y libvorbis-dev libtheora-dev libphysfs-dev libdumb1-dev libflac-dev libpulse-dev libgtk2.0-dev pandoc libcurl4-nss-dev libenet-dev pulseaudio;
@@ -16,18 +27,11 @@ before_install:
          sudo apt-get update -q;
          sudo apt-get install -y liballegro5-dev;
       elif [ `uname` = "Darwin" ]; then
-         git clone https://github.com/google/googletest
-         cd googletest
-         mkdir build
-         cd build
-         cmake ..
-         make
-         make install
          brew install opusfile libvorbis freetype flac physfs;
          brew install allegro;
       fi
 
 script:
   - make
-  - make examples
   - make tests
+  - make examples

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ before_install:
          sudo apt-get update -q;
          sudo apt-get install -y liballegro5-dev;
       elif [ `uname` = "Darwin" ]; then
-         brew install opusfile libvorbis freetype flac physfs;
-         brew install allegro;
-         brew install boost;
          git clone https://github.com/google/googletest
          cd googletest
          mkdir build
@@ -26,6 +23,8 @@ before_install:
          cmake ..
          make
          make install
+         brew install opusfile libvorbis freetype flac physfs;
+         brew install allegro;
       fi
 
 script:

--- a/tests/achievements_test.cpp
+++ b/tests/achievements_test.cpp
@@ -1,0 +1,28 @@
+
+
+
+#include <gtest/gtest.h>
+
+#include <AllegroFlare/Achievements.hpp>
+
+
+
+using namespace AllegroFlare;
+
+
+
+TEST(AchievementsTest, can_be_created_without_arguments)
+{
+   Achievements achievements;
+}
+
+
+
+int main(int argc, char **argv)
+{
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}
+
+
+

--- a/tests/keyboard_command_mapper_test.cpp
+++ b/tests/keyboard_command_mapper_test.cpp
@@ -1,0 +1,67 @@
+
+
+
+#include <gtest/gtest.h>
+
+#include <allegro_flare/keyboard_command_mapper.h>
+
+
+
+using namespace allegro_flare;
+
+
+
+
+TEST(KeyboardCommandMapperTest, can_get_and_set_mappings)
+{
+   KeyboardCommandMapper mapper;
+
+   std::vector<std::string> command_identifiers = {"this_is_the_command"};
+
+   EXPECT_TRUE(mapper.set_mapping(14 /*ALLEGRO_KEY_N*/, true, false, true, command_identifiers));
+   EXPECT_EQ(command_identifiers, mapper.get_mapping(14 /*ALLEGRO_KEY_N*/, true, false, true));
+}
+
+
+
+TEST(KeyboardCommandMapperTest, can_get_and_set_all_valid_allegro_keycodes)
+{
+   KeyboardCommandMapper mapper;
+
+   for (unsigned k=0 /*ALLEGRO_KEY_A*/; k<215/*ALLEGRO_KEY_MODIFIERS*/; k++)
+   {
+      std::vector<std::string> mapped_command_identifiers = {"this is a test identifier"};
+
+      EXPECT_TRUE(                          mapper.set_mapping(k, true, true, true, mapped_command_identifiers));
+      EXPECT_EQ(mapped_command_identifiers, mapper.get_mapping(k, true, true, true));
+
+      EXPECT_TRUE(                          mapper.set_mapping(k, true, false, true, mapped_command_identifiers));
+      EXPECT_EQ(mapped_command_identifiers, mapper.get_mapping(k, true, false, true));
+
+      EXPECT_TRUE(                          mapper.set_mapping(k, true, true, false, mapped_command_identifiers));
+      EXPECT_EQ(mapped_command_identifiers, mapper.get_mapping(k, true, true, false));
+   }
+}
+
+
+
+TEST(KeyboardCommandMapperTest, returns_an_empty_vector_if_identifier_is_not_found)
+{
+   KeyboardCommandMapper mapper;
+   std::vector<std::string> expected_return_value = {};
+
+   EXPECT_EQ(expected_return_value, mapper.get_mapping(16, true, false, false));
+   EXPECT_EQ(expected_return_value, mapper.get_mapping(24, false, true, false));
+   EXPECT_EQ(expected_return_value, mapper.get_mapping(0, false, false, true));
+}
+
+
+
+int main(int argc, char **argv)
+{
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}
+
+
+


### PR DESCRIPTION
## Problem

There is a mixture of Boost Test & Google Test tests, but Google Test tests are not setup to build correctly in `.travis.yml`.

## Solution

This PR adds an install step for googletest (could not find a simple `brew install googletest` or `brew install gtest`), and adds 2 Google Test tests - one for `Achievements` and another for `KeyboardCommandMapper`.

* The two tests added are added directly into the `tests/` directory.  One test is for an `AllegroFlare/` component and another is for `allegro_flare/`. Tests should eventually be placed into `tests/AllegroFlare/` and `tests/allegro_flare/` folders respectively, but that move will happen later.  This PR focuses on setting up Google Test for travis.

* The `brew install boost` line in the `.travis.yml` was removed because it causes a build error: <img width="353" alt="allegro_flare - Travis CI 2019-10-19 04-40-58" src="https://user-images.githubusercontent.com/772949/67140670-c0e08a80-f22a-11e9-88aa-8da97841b636.png">
