### PR TITLE
Run "make documentation" During CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,12 @@ before_install:
 
 script:
   - make
-  - make tests
-  - make examples
-  - make documentation
+  - if [ `uname` = "Darwin" ]; then
+      make tests;
+    fi
+  - if [ `uname` = "Darwin" ]; then
+      make examples;
+    fi
+  - if [ `uname` = "Darwin" ]; then
+      make documentation
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
       elif [ `uname` = "Darwin" ]; then
          brew install opusfile libvorbis freetype flac physfs;
          brew install allegro;
-         pip install pygccxml
+         pip install pygccxml;
       fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ before_install:
       elif [ `uname` = "Darwin" ]; then
          brew install opusfile libvorbis freetype flac physfs;
          brew install allegro;
-         pip install pygccxml;
       fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
       fi
     - if [ `uname` = "Darwin" ]; then
         brew install castxml;
-        git clone git@github.com:gccxml/pygccxml.git;
+        git clone https://github.com/gccxml/pygccxml.git;
         cd pygccxml;
         python setup.py install;
         cd ..;

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,11 @@ before_install:
       elif [ `uname` = "Darwin" ]; then
          brew install opusfile libvorbis freetype flac physfs;
          brew install allegro;
+         pip install pygccxml
       fi
 
 script:
   - make
   - make tests
   - make examples
+  - make documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,13 @@ before_install:
       fi
 
 script:
+  - make
+  - if [ `uname` = "Darwin" ]; then
+      make tests;
+    fi
+  - if [ `uname` = "Darwin" ]; then
+      make examples;
+    fi
   - if [ `uname` = "Darwin" ]; then
       make documentation;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,13 +39,6 @@ before_install:
       fi
 
 script:
-  - make
-  - if [ `uname` = "Darwin" ]; then
-      make tests;
-    fi
-  - if [ `uname` = "Darwin" ]; then
-      make examples;
-    fi
   - if [ `uname` = "Darwin" ]; then
       make documentation;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,13 @@ before_install:
          cd ..;
          cd ..;
       fi
+    - if [ `uname` = "Darwin" ]; then
+        brew install castxml;
+        git clone git@github.com:gccxml/pygccxml.git;
+        cd pygccxml;
+        python setup.py install;
+        cd ..;
+      fi
     - if [ `uname` = "Linux" ]; then
          sudo apt-get update;
          sudo apt-get install -y libvorbis-dev libtheora-dev libphysfs-dev libdumb1-dev libflac-dev libpulse-dev libgtk2.0-dev pandoc libcurl4-nss-dev libenet-dev pulseaudio;

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,5 +47,5 @@ script:
       make examples;
     fi
   - if [ `uname` = "Darwin" ]; then
-      make documentation
+      make documentation;
     fi

--- a/docs/build_scripts/parse_source.py
+++ b/docs/build_scripts/parse_source.py
@@ -148,7 +148,7 @@ def parse_file(filename):
         docs_c.execute('SELECT * FROM entries WHERE decl=?', (item, ))
         entries = docs_c.fetchall()
         if len(entries) == 0:
-            print item
+            print(item)
             unfound_items += 1
         else:
             print_green(item + " - FOUND")
@@ -181,5 +181,5 @@ count = 0
 num_header_files = len(header_files) 
 for f in header_files:
     count = count + 1
-    print "===== parsing " + str(count) + " of " + str(num_header_files) + " ====="
+    print("===== parsing " + str(count) + " of " + str(num_header_files) + " =====")
     parse_file(f)


### PR DESCRIPTION
## Problem

Documentation currently does not build.

## Solution

Tweak the build stages in `.travis.ci` to install the necessary dependencies and run `make documentation`.

* `docs/build_scripts/parse_source.py` had some syntax errors.
* Also included here is a gating of `make tests`, `make examples`, and `make documentation so that these stages are not run on other platforms.

## Success!

<img width="504" alt="allegro_flare - Travis CI 2019-10-19 11-49-00" src="https://user-images.githubusercontent.com/772949/67147816-84cb1b00-f266-11e9-86c6-c3e3f70c91c6.png">