### PR TITLE
[WIP] Have a nice Color class

### DIFF
--- a/include/AllegroFlare/Color.hpp
+++ b/include/AllegroFlare/Color.hpp
@@ -4,12 +4,43 @@
 #include <string>
 #include <allegro5/allegro.h>
 #include <allegro5/allegro_color.h>
+#include <iostream>
+//#include <AllegroFlare/Useful.hpp>
 //#include <allegro_flare/color_names.h>
 
 
 
 namespace AllegroFlare
 {
+   class Color
+   {
+   private:
+   public:
+      static inline float clamp_color(float v);
+      
+      Color();
+      ~Color();
+      Color(float r, float g, float b, float a = 1.0f);
+      Color(ALLEGRO_COLOR allegro_color);
+      Color(std::string color_name, float alpha = 1.0f);
+      Color(int hex, float alpha = 1.0f);
+      
+      static Color rgba(int r, int g, int b, float a = 1.0f);
+      
+      Color mix(Color &c1, Color &c2, float scale = 0.5f);
+      
+      Color operator+(const Color &c2);
+      Color operator-(const Color &c2);
+      Color operator*(const Color &c2);
+      
+      friend std::ostream& operator<<(std::ostream& os, const Color& c);
+      
+      float r, g, b, a;
+   };
+   
+   Color operator*(const Color &c, float k);
+   Color operator*(float k, const Color &c);
+   
    ALLEGRO_COLOR operator+(const ALLEGRO_COLOR& lhs, const ALLEGRO_COLOR& rhs);
    ALLEGRO_COLOR operator-(const ALLEGRO_COLOR& lhs, const ALLEGRO_COLOR& rhs);
    ALLEGRO_COLOR operator*(const ALLEGRO_COLOR& lhs, const ALLEGRO_COLOR& rhs);
@@ -249,8 +280,4 @@ namespace AllegroFlare
    }
 
 
-
-
 }
-
-

--- a/src/AllegroFlare/Color.cpp
+++ b/src/AllegroFlare/Color.cpp
@@ -6,14 +6,125 @@
 
 #include <algorithm>
 #include <cmath>
-#include <math.h>
 #include <sstream>
+#include <iostream>
 
 
 
 
 namespace AllegroFlare
 {
+   inline float Color::clamp_color(float v){
+      return (v>1.0f) ? 1.0f : ((v<0.0f) ? 0.0f : v);
+   }
+   
+   Color::Color() : r(0.0f), g(0.0f), b(0.0f), a(0.0f)
+   {}
+   
+   Color::Color(ALLEGRO_COLOR allegro_color)
+   {
+      r = allegro_color.r;
+      g = allegro_color.g;
+      b = allegro_color.b;
+      a = allegro_color.a;
+   }
+   
+   Color::Color(int hex, float alpha)
+   {
+      r = (float)(hex & 0xFF0000)/0xFF0000;
+      g = (float)(hex & 0x00FF00)/0xFF00;
+      b = (float)(hex & 0x0000FF)/0xFF;
+   }
+   
+   Color::Color(float r, float g, float b, float a)
+   {
+      this->r = r;
+      this->g = g;
+      this->b = b;
+      this->a = a;
+   }
+   
+   Color Color::rgba(int r, int g, int b, float a)
+   {
+      return Color(
+         (float)r/255,
+         (float)g/255,
+         (float)b/255,
+         a);
+   }
+   
+   Color::Color(std::string color_name, float alpha)
+   {
+      ALLEGRO_COLOR color = al_color_name(color_name.c_str());
+      r = color.r;
+      g = color.g;
+      b = color.b;
+      a = alpha;
+   }
+   
+   Color Color::mix(Color &c1, Color &c2, float scale)
+   {
+      Color col;
+      col.r = (c2.r - c1.r) * scale + c1.r;
+      col.g = (c2.g - c1.g) * scale + c1.g;
+      col.b = (c2.b - c1.b) * scale + c1.b;
+      col.a = (c2.a - c1.a) * scale + c1.a;
+      return col;
+   }
+   
+   Color::~Color()
+   {}
+   
+   Color Color::operator+(const Color &c2){
+      return Color(
+         clamp_color(r + c2.r),
+         clamp_color(g + c2.g),
+         clamp_color(b + c2.b),
+         clamp_color(a + c2.a)
+      );
+   }
+   
+   Color Color::operator-(const Color &c2){
+      return Color(
+         clamp_color(r - c2.r),
+         clamp_color(g - c2.g),
+         clamp_color(b - c2.b),
+         clamp_color(a - c2.a)
+      );
+   }
+   
+   Color Color::operator*(const Color &c2){
+      return Color(
+         clamp_color(r * c2.r),
+         clamp_color(g * c2.g),
+         clamp_color(b * c2.b),
+         clamp_color(a * c2.a)
+      );
+   }
+   
+   Color operator*(const Color &c, float k){
+      return Color(
+         Color::clamp_color(c.r * k),
+         Color::clamp_color(c.g * k),
+         Color::clamp_color(c.b * k),
+         c.a // alpha value really shouldn't be modified by a multiplication with a float
+      );
+   }
+   
+   Color operator*(float k, const Color &c){
+      return Color(
+         Color::clamp_color(c.r * k),
+         Color::clamp_color(c.g * k),
+         Color::clamp_color(c.b * k),
+         c.a // alpha value really shouldn't be modified by a multiplication with a float
+      );
+   }
+   
+   std::ostream& operator<<(std::ostream& os, const Color &c){
+      os << "rgba(" << c.r*255 << "," << c.g*255 << "," << c.b*255 << "," << c.a << ")";
+      return os;
+   }
+   
    ALLEGRO_COLOR operator+(const ALLEGRO_COLOR& lhs, const ALLEGRO_COLOR& rhs)
    {
       ALLEGRO_COLOR result;


### PR DESCRIPTION
This will actually require a major overhaul of the whole lib !
Why ? Because we need all functions using `ALLEGRO_COLOR` to use this class.
Also, to make things more C++-style, it would be nice to create a wrapper for **all** Allegro functions, for Bitmaps, etc, so that you **never** have to deal with pointers manually. But this will be done in another pull request I think.
For now, compatibility will be ensure by adding a casting operator to the `Color` class.