### PR TITLE
Add Elements/Stopwatch

### DIFF
--- a/documentation/dependents.json
+++ b/documentation/dependents.json
@@ -117,6 +117,9 @@
   "ALLEGRO_DISPLAY": [
     "AllegroFlare/Testing/WithAllegroRenderingFixture"
   ],
+  "al_color_name": [
+    "AllegroFlare/Testing/WithAllegroRenderingFixture"
+  ],
   "AllegroFlare/BitmapBin": [
     "AllegroFlare/Testing/WithAllegroRenderingFixture"
   ],

--- a/documentation/dependents.json
+++ b/documentation/dependents.json
@@ -33,11 +33,13 @@
   ],
   "AllegroFlare/FontBin": [
     "AllegroFlare/Bone3DGraphRenderer",
+    "AllegroFlare/Elements/Stopwatch",
     "AllegroFlare/Elements/Text",
     "AllegroFlare/Testing/WithAllegroRenderingFixture"
   ],
   "ALLEGRO_FONT": [
     "AllegroFlare/Bone3DGraphRenderer",
+    "AllegroFlare/Elements/Stopwatch",
     "AllegroFlare/Elements/Text",
     "AllegroFlare/Testing/WithAllegroRenderingFixture"
   ],
@@ -70,12 +72,22 @@
   ],
   "AllegroFlare/Elements/Base": [
     "AllegroFlare/Elements/HealthBars/Classic",
+    "AllegroFlare/Elements/Stopwatch",
     "AllegroFlare/Elements/Text"
   ],
   "ALLEGRO_COLOR": [
     "AllegroFlare/Elements/HealthBars/Classic",
     "AllegroFlare/Elements/Text",
     "AllegroFlare/Useful3D/Triangle"
+  ],
+  "AllegroFlare/TimerFormatter": [
+    "AllegroFlare/Elements/Stopwatch"
+  ],
+  "AllegroFlare/Color/White": [
+    "AllegroFlare/Elements/Stopwatch"
+  ],
+  "AllegroFlare/Timer": [
+    "AllegroFlare/Elements/Stopwatch"
   ],
   "al_draw_text": [
     "AllegroFlare/Elements/Text"

--- a/documentation/dependents.json
+++ b/documentation/dependents.json
@@ -77,13 +77,11 @@
   ],
   "ALLEGRO_COLOR": [
     "AllegroFlare/Elements/HealthBars/Classic",
+    "AllegroFlare/Elements/Stopwatch",
     "AllegroFlare/Elements/Text",
     "AllegroFlare/Useful3D/Triangle"
   ],
   "AllegroFlare/TimerFormatter": [
-    "AllegroFlare/Elements/Stopwatch"
-  ],
-  "AllegroFlare/Color/White": [
     "AllegroFlare/Elements/Stopwatch"
   ],
   "AllegroFlare/Timer": [

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -455,6 +455,9 @@ table td
   <td class="method">is_running()</td>
 </tr>
 <tr>
+  <td class="private_method">fit_placement_width_and_height_to_stopwatch()</td>
+</tr>
+<tr>
   <td class="method">render()</td>
 </tr>
 <tr>
@@ -633,6 +636,9 @@ table td
 <tr>
   <td class="method">build_centered_placement(2)</td>
 </tr>
+<tr>
+  <td class="method">draw_rulers()</td>
+</tr>
     </table>
      <table>
 <tr>
@@ -655,6 +661,9 @@ table td
 </tr>
 <tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;ALLEGRO_FONT*&quot;, &quot;headers&quot;=&gt;[&quot;allegro5/allegro_font.h&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;al_color_name&quot;, &quot;headers&quot;=&gt;[&quot;allegro5/allegro_color.h&quot;]}</td>
 </tr>
 <tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::FontBin&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/FontBin.hpp&quot;]}</td>
@@ -1086,6 +1095,9 @@ table td
     "AllegroFlare/Testing/WithAllegroRenderingFixture"
   ],
   "ALLEGRO_DISPLAY": [
+    "AllegroFlare/Testing/WithAllegroRenderingFixture"
+  ],
+  "al_color_name": [
     "AllegroFlare/Testing/WithAllegroRenderingFixture"
   ],
   "AllegroFlare/BitmapBin": [

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -57,6 +57,7 @@ table td
   <li><a href="#quintessence/AllegroFlare/Cubemap.q.yml">quintessence/AllegroFlare/Cubemap.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/Elements/Base.q.yml">quintessence/AllegroFlare/Elements/Base.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/Elements/HealthBars/Classic.q.yml">quintessence/AllegroFlare/Elements/HealthBars/Classic.q.yml</a></li>
+  <li><a href="#quintessence/AllegroFlare/Elements/Stopwatch.q.yml">quintessence/AllegroFlare/Elements/Stopwatch.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/Elements/Text.q.yml">quintessence/AllegroFlare/Elements/Text.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/EventEmitter.q.yml">quintessence/AllegroFlare/EventEmitter.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/Testing/WithAllegroRenderingFixture.q.yml">quintessence/AllegroFlare/Testing/WithAllegroRenderingFixture.q.yml</a></li>
@@ -419,6 +420,61 @@ table td
 </tr>
 <tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;ALLEGRO_COLOR&quot;, &quot;headers&quot;=&gt;[&quot;allegro5/allegro.h&quot;]}</td>
+</tr>
+    </table>
+  </div>
+</ul>
+<ul>
+  <div class="component">
+    <h3 id="quintessence/AllegroFlare/Elements/Stopwatch.q.yml">quintessence/AllegroFlare/Elements/Stopwatch.q.yml</h3>
+     <table>
+<tr>
+  <td class="property">font_bin</td>
+  <td class="property">AllegroFlare::FontBin*</td>
+</tr>
+<tr>
+  <td class="property">timer</td>
+  <td class="property">AllegroFlare::Timer</td>
+</tr>
+    </table>
+     <table>
+<tr>
+  <td class="method">start()</td>
+</tr>
+<tr>
+  <td class="method">pause()</td>
+</tr>
+<tr>
+  <td class="method">reset()</td>
+</tr>
+<tr>
+  <td class="method">is_running()</td>
+</tr>
+<tr>
+  <td class="method">render()</td>
+</tr>
+<tr>
+  <td class="private_method">obtain_font()</td>
+</tr>
+    </table>
+     <table>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::Elements::Base&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/Elements/Base.hpp&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::FontBin*&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/FontBin.hpp&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::TimerFormatter&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/TimerFormatter.hpp&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::Color::White&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/Color.hpp&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::Timer&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/Timer.hpp&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;ALLEGRO_FONT*&quot;, &quot;headers&quot;=&gt;[&quot;allegro5/allegro_font.h&quot;]}</td>
 </tr>
     </table>
   </div>
@@ -941,11 +997,13 @@ table td
   ],
   "AllegroFlare/FontBin": [
     "AllegroFlare/Bone3DGraphRenderer",
+    "AllegroFlare/Elements/Stopwatch",
     "AllegroFlare/Elements/Text",
     "AllegroFlare/Testing/WithAllegroRenderingFixture"
   ],
   "ALLEGRO_FONT": [
     "AllegroFlare/Bone3DGraphRenderer",
+    "AllegroFlare/Elements/Stopwatch",
     "AllegroFlare/Elements/Text",
     "AllegroFlare/Testing/WithAllegroRenderingFixture"
   ],
@@ -978,12 +1036,22 @@ table td
   ],
   "AllegroFlare/Elements/Base": [
     "AllegroFlare/Elements/HealthBars/Classic",
+    "AllegroFlare/Elements/Stopwatch",
     "AllegroFlare/Elements/Text"
   ],
   "ALLEGRO_COLOR": [
     "AllegroFlare/Elements/HealthBars/Classic",
     "AllegroFlare/Elements/Text",
     "AllegroFlare/Useful3D/Triangle"
+  ],
+  "AllegroFlare/TimerFormatter": [
+    "AllegroFlare/Elements/Stopwatch"
+  ],
+  "AllegroFlare/Color/White": [
+    "AllegroFlare/Elements/Stopwatch"
+  ],
+  "AllegroFlare/Timer": [
+    "AllegroFlare/Elements/Stopwatch"
   ],
   "al_draw_text": [
     "AllegroFlare/Elements/Text"

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -436,6 +436,10 @@ table td
   <td class="property">timer</td>
   <td class="property">AllegroFlare::Timer</td>
 </tr>
+<tr>
+  <td class="property">color</td>
+  <td class="property">ALLEGRO_COLOR</td>
+</tr>
     </table>
      <table>
 <tr>
@@ -454,6 +458,9 @@ table td
   <td class="method">render()</td>
 </tr>
 <tr>
+  <td class="private_method">build_ellapsed_time_str()</td>
+</tr>
+<tr>
   <td class="private_method">obtain_font()</td>
 </tr>
     </table>
@@ -468,13 +475,13 @@ table td
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::TimerFormatter&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/TimerFormatter.hpp&quot;]}</td>
 </tr>
 <tr>
-  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::Color::White&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/Color.hpp&quot;]}</td>
-</tr>
-<tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::Timer&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/Timer.hpp&quot;]}</td>
 </tr>
 <tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;ALLEGRO_FONT*&quot;, &quot;headers&quot;=&gt;[&quot;allegro5/allegro_font.h&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;ALLEGRO_COLOR&quot;, &quot;headers&quot;=&gt;[&quot;allegro5/allegro.h&quot;]}</td>
 </tr>
     </table>
   </div>
@@ -1041,13 +1048,11 @@ table td
   ],
   "ALLEGRO_COLOR": [
     "AllegroFlare/Elements/HealthBars/Classic",
+    "AllegroFlare/Elements/Stopwatch",
     "AllegroFlare/Elements/Text",
     "AllegroFlare/Useful3D/Triangle"
   ],
   "AllegroFlare/TimerFormatter": [
-    "AllegroFlare/Elements/Stopwatch"
-  ],
-  "AllegroFlare/Color/White": [
     "AllegroFlare/Elements/Stopwatch"
   ],
   "AllegroFlare/Timer": [

--- a/include/AllegroFlare/Color.hpp
+++ b/include/AllegroFlare/Color.hpp
@@ -47,6 +47,7 @@ namespace AllegroFlare
       static const ALLEGRO_COLOR Red;
       static const ALLEGRO_COLOR White;
       static const ALLEGRO_COLOR MintCream;
+      static const ALLEGRO_COLOR Aquamarine;
    };
    
    Color operator*(const Color &c, float k);

--- a/include/AllegroFlare/Color.hpp
+++ b/include/AllegroFlare/Color.hpp
@@ -45,6 +45,7 @@ namespace AllegroFlare
       static const ALLEGRO_COLOR Nothing;
       static const ALLEGRO_COLOR Null;
       static const ALLEGRO_COLOR Red;
+      static const ALLEGRO_COLOR White;
       static const ALLEGRO_COLOR MintCream;
    };
    

--- a/include/AllegroFlare/Elements/Stopwatch.hpp
+++ b/include/AllegroFlare/Elements/Stopwatch.hpp
@@ -1,25 +1,30 @@
 #pragma once
 
 
+#include <AllegroFlare/Elements/Base.hpp>
 #include <AllegroFlare/FontBin.hpp>
+#include <AllegroFlare/Timer.hpp>
 #include <allegro5/allegro_font.h>
-#include <string>
 
 
 namespace AllegroFlare
 {
    namespace Elements
    {
-      class Stopwatch
+      class Stopwatch : public AllegroFlare::Elements::Base
       {
       private:
          AllegroFlare::FontBin* font_bin;
-         std::string quote;
+         AllegroFlare::Timer timer;
 
       public:
          Stopwatch(AllegroFlare::FontBin* font_bin=nullptr);
          ~Stopwatch();
 
+         void start();
+         void pause();
+         void reset();
+         void is_running();
          void render();
          ALLEGRO_FONT* obtain_font();
       };

--- a/include/AllegroFlare/Elements/Stopwatch.hpp
+++ b/include/AllegroFlare/Elements/Stopwatch.hpp
@@ -30,6 +30,7 @@ namespace AllegroFlare
          void pause();
          void reset();
          void is_running();
+         void fit_placement_width_and_height_to_stopwatch();
          void render();
          std::string build_ellapsed_time_str();
          ALLEGRO_FONT* obtain_font();

--- a/include/AllegroFlare/Elements/Stopwatch.hpp
+++ b/include/AllegroFlare/Elements/Stopwatch.hpp
@@ -4,7 +4,9 @@
 #include <AllegroFlare/Elements/Base.hpp>
 #include <AllegroFlare/FontBin.hpp>
 #include <AllegroFlare/Timer.hpp>
+#include <allegro5/allegro.h>
 #include <allegro5/allegro_font.h>
+#include <string>
 
 
 namespace AllegroFlare
@@ -16,16 +18,20 @@ namespace AllegroFlare
       private:
          AllegroFlare::FontBin* font_bin;
          AllegroFlare::Timer timer;
+         ALLEGRO_COLOR color;
 
       public:
          Stopwatch(AllegroFlare::FontBin* font_bin=nullptr);
          ~Stopwatch();
 
+         void set_color(ALLEGRO_COLOR color);
+         ALLEGRO_COLOR get_color();
          void start();
          void pause();
          void reset();
          void is_running();
          void render();
+         std::string build_ellapsed_time_str();
          ALLEGRO_FONT* obtain_font();
       };
    }

--- a/include/AllegroFlare/Elements/Stopwatch.hpp
+++ b/include/AllegroFlare/Elements/Stopwatch.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+
+#include <AllegroFlare/FontBin.hpp>
+#include <allegro5/allegro_font.h>
+#include <string>
+
+
+namespace AllegroFlare
+{
+   namespace Elements
+   {
+      class Stopwatch
+      {
+      private:
+         AllegroFlare::FontBin* font_bin;
+         std::string quote;
+
+      public:
+         Stopwatch(AllegroFlare::FontBin* font_bin=nullptr);
+         ~Stopwatch();
+
+         void render();
+         ALLEGRO_FONT* obtain_font();
+      };
+   }
+}
+
+
+

--- a/include/AllegroFlare/Placement2D.hpp
+++ b/include/AllegroFlare/Placement2D.hpp
@@ -32,7 +32,7 @@ namespace AllegroFlare
       void restore_transform();
       void build_transform(ALLEGRO_TRANSFORM *transform);
       void build_reverse_transform(ALLEGRO_TRANSFORM *transform);
-      void draw_box(ALLEGRO_COLOR color, bool draw_origin);
+      void draw_box(ALLEGRO_COLOR color, bool draw_origin=false);
       void draw_box_with_padding(ALLEGRO_COLOR color, bool draw_origin, float pt, float pr, float pb, float pl);
       void draw_origin();
       void clear();

--- a/include/AllegroFlare/Testing/WithAllegroRenderingFixture.hpp
+++ b/include/AllegroFlare/Testing/WithAllegroRenderingFixture.hpp
@@ -36,6 +36,7 @@ namespace AllegroFlare
          std::string get_test_name();
          std::string get_test_suite_name();
          AllegroFlare::Placement2D build_centered_placement(float width=0.0f, float height=0.0f);
+         void draw_rulers();
       };
    }
 }

--- a/quintessence/AllegroFlare/Elements/Stopwatch.q.yml
+++ b/quintessence/AllegroFlare/Elements/Stopwatch.q.yml
@@ -18,6 +18,12 @@ properties:
     type: AllegroFlare::Timer
     init_with: '{}'
 
+  - name: color
+    type: ALLEGRO_COLOR
+    init_with: ALLEGRO_COLOR{1, 1, 1, 1}
+    getter: true
+    setter: true
+
 
 functions:
 
@@ -50,9 +56,8 @@ functions:
     type: void
     guards: [ al_is_system_installed(), al_is_font_addon_initialized(), font_bin ]
     body: |
-      ALLEGRO_COLOR color = AllegroFlare::Color::White;
       ALLEGRO_FONT *font = obtain_font();
-      std::string ellapsed_time_str = AllegroFlare::TimerFormatter(timer.get_elapsed_time_milliseconds()).format();
+      std::string ellapsed_time_str = build_ellapsed_time_str();
 
       get_placement_ref().start_transform();
       al_draw_text(font, color, 0, 0, ALLEGRO_ALIGN_LEFT, ellapsed_time_str.c_str());
@@ -60,7 +65,13 @@ functions:
       return;
     body_dependency_symbols:
       - AllegroFlare::TimerFormatter
-      - AllegroFlare::Color::White
+
+
+  - name: build_ellapsed_time_str
+    type: std::string
+    private: true
+    body: |
+      return AllegroFlare::TimerFormatter(timer.get_elapsed_time_milliseconds()).format();
 
 
   - name: obtain_font
@@ -80,11 +91,11 @@ dependencies:
     headers: [ AllegroFlare/FontBin.hpp ]
   - symbol: AllegroFlare::TimerFormatter
     headers: [ AllegroFlare/TimerFormatter.hpp ]
-  - symbol: AllegroFlare::Color::White
-    headers: [ AllegroFlare/Color.hpp ]
   - symbol: AllegroFlare::Timer
     headers: [ AllegroFlare/Timer.hpp ]
   - symbol: ALLEGRO_FONT*
     headers: [ allegro5/allegro_font.h ]
+  - symbol: ALLEGRO_COLOR
+    headers: [ allegro5/allegro.h ]
 
 

--- a/quintessence/AllegroFlare/Elements/Stopwatch.q.yml
+++ b/quintessence/AllegroFlare/Elements/Stopwatch.q.yml
@@ -52,6 +52,18 @@ functions:
       return;
 
 
+  - name: fit_placement_width_and_height_to_stopwatch
+    guards: [ al_is_system_installed(), al_is_font_addon_initialized(), font_bin ]
+    private: true
+    body: |
+      std::string ellapsed_time_str = build_ellapsed_time_str();
+      float width = al_get_text_width(obtain_font(), ellapsed_time_str.c_str());
+      float height = al_get_font_line_height(obtain_font());
+      get_placement_ref().size.x = width;
+      get_placement_ref().size.y = height;
+      return;
+
+
   - name: render
     type: void
     guards: [ al_is_system_installed(), al_is_font_addon_initialized(), font_bin ]

--- a/quintessence/AllegroFlare/Elements/Stopwatch.q.yml
+++ b/quintessence/AllegroFlare/Elements/Stopwatch.q.yml
@@ -1,0 +1,38 @@
+properties:
+
+
+  - name: font_bin
+    type: AllegroFlare::FontBin*
+    init_with: nullptr
+    constructor_arg: true
+
+  - name: quote
+    type: std::string
+    init_with: '{}'
+
+
+functions:
+
+
+  - name: render
+    type: void
+    guards: [ al_is_system_installed(), al_is_font_addon_initialized(), font_bin ]
+    body: |
+      return;
+
+  - name: obtain_font
+    private: true
+    type: ALLEGRO_FONT*
+    guards: [ font_bin ]
+    body: |
+      return font_bin->auto_get("Purista Medium.otf -32");
+
+
+dependencies:
+
+
+  - symbol: AllegroFlare::FontBin*
+    headers: [ AllegroFlare/FontBin.hpp ]
+  - symbol: ALLEGRO_FONT*
+    headers: [ allegro5/allegro_font.h ]
+

--- a/quintessence/AllegroFlare/Elements/Stopwatch.q.yml
+++ b/quintessence/AllegroFlare/Elements/Stopwatch.q.yml
@@ -1,3 +1,11 @@
+parent_classes:
+
+
+  - class: AllegroFlare::Elements::Base
+    scope: public
+    init_with: ''
+
+
 properties:
 
 
@@ -6,33 +14,77 @@ properties:
     init_with: nullptr
     constructor_arg: true
 
-  - name: quote
-    type: std::string
+  - name: timer
+    type: AllegroFlare::Timer
     init_with: '{}'
 
 
 functions:
 
 
+  - name: start
+    body: |
+      timer.start();
+      return;
+
+
+  - name: pause
+    body: |
+      timer.pause();
+      return;
+
+
+  - name: reset
+    body: |
+      timer.reset();
+      return;
+
+
+  - name: is_running
+    body: |
+      timer.is_running();
+      return;
+
+
   - name: render
     type: void
     guards: [ al_is_system_installed(), al_is_font_addon_initialized(), font_bin ]
     body: |
+      ALLEGRO_COLOR color = AllegroFlare::Color::White;
+      ALLEGRO_FONT *font = obtain_font();
+      std::string ellapsed_time_str = AllegroFlare::TimerFormatter(timer.get_elapsed_time_milliseconds()).format();
+
+      get_placement_ref().start_transform();
+      al_draw_text(font, color, 0, 0, ALLEGRO_ALIGN_LEFT, ellapsed_time_str.c_str());
+      get_placement_ref().restore_transform();
       return;
+    body_dependency_symbols:
+      - AllegroFlare::TimerFormatter
+      - AllegroFlare::Color::White
+
 
   - name: obtain_font
     private: true
     type: ALLEGRO_FONT*
     guards: [ font_bin ]
     body: |
-      return font_bin->auto_get("Purista Medium.otf -32");
+      return font_bin->auto_get("DroidSans.ttf -74");
 
 
 dependencies:
 
 
+  - symbol: AllegroFlare::Elements::Base
+    headers: [ AllegroFlare/Elements/Base.hpp ]
   - symbol: AllegroFlare::FontBin*
     headers: [ AllegroFlare/FontBin.hpp ]
+  - symbol: AllegroFlare::TimerFormatter
+    headers: [ AllegroFlare/TimerFormatter.hpp ]
+  - symbol: AllegroFlare::Color::White
+    headers: [ AllegroFlare/Color.hpp ]
+  - symbol: AllegroFlare::Timer
+    headers: [ AllegroFlare/Timer.hpp ]
   - symbol: ALLEGRO_FONT*
     headers: [ allegro5/allegro_font.h ]
+
 

--- a/quintessence/AllegroFlare/Testing/WithAllegroRenderingFixture.q.yml
+++ b/quintessence/AllegroFlare/Testing/WithAllegroRenderingFixture.q.yml
@@ -148,6 +148,15 @@ functions:
       return place;
 
 
+  - name: draw_rulers
+    guards: [ al_get_target_bitmap() ]
+    body: |
+      al_draw_line(1920/2, 0, 1920/2, 1080, al_color_name("gray"), 1.0); // rulers down the center
+      al_draw_line(0, 1080/2, 1920, 1080/2, al_color_name("gray"), 1.0); // rulers across the middle
+    body_dependency_symbols:
+      - al_color_name
+
+
 dependencies:
 
 
@@ -165,6 +174,8 @@ dependencies:
     headers: [ allegro5/allegro.h ]
   - symbol: ALLEGRO_FONT*
     headers: [ allegro5/allegro_font.h ]
+  - symbol: al_color_name
+    headers: [ allegro5/allegro_color.h ]
   - symbol: AllegroFlare::FontBin
     headers: [ AllegroFlare/FontBin.hpp ]
   - symbol: AllegroFlare::BitmapBin

--- a/src/AllegroFlare/Color.cpp
+++ b/src/AllegroFlare/Color.cpp
@@ -80,6 +80,7 @@ namespace AllegroFlare
    const ALLEGRO_COLOR Color::Nothing = Eigengrau;
    const ALLEGRO_COLOR Color::Null = ALLEGRO_COLOR{0, 0, 0, 1};
    const ALLEGRO_COLOR Color::Red = ALLEGRO_COLOR{1, 0, 0, 1};
+   const ALLEGRO_COLOR Color::White = ALLEGRO_COLOR{1, 1, 1, 1};
    const ALLEGRO_COLOR Color::MintCream = al_color_name("mintcream");
 
 

--- a/src/AllegroFlare/Color.cpp
+++ b/src/AllegroFlare/Color.cpp
@@ -82,6 +82,7 @@ namespace AllegroFlare
    const ALLEGRO_COLOR Color::Red = ALLEGRO_COLOR{1, 0, 0, 1};
    const ALLEGRO_COLOR Color::White = ALLEGRO_COLOR{1, 1, 1, 1};
    const ALLEGRO_COLOR Color::MintCream = al_color_name("mintcream");
+   const ALLEGRO_COLOR Color::Aquamarine = al_color_name("aquamarine");
 
 
    

--- a/src/AllegroFlare/Elements/Stopwatch.cpp
+++ b/src/AllegroFlare/Elements/Stopwatch.cpp
@@ -1,0 +1,64 @@
+
+
+#include <AllegroFlare/Elements/Stopwatch.hpp>
+#include <stdexcept>
+#include <sstream>
+#include <stdexcept>
+#include <sstream>
+
+
+namespace AllegroFlare
+{
+namespace Elements
+{
+
+
+Stopwatch::Stopwatch(AllegroFlare::FontBin* font_bin)
+   : font_bin(font_bin)
+   , quote({})
+{
+}
+
+
+Stopwatch::~Stopwatch()
+{
+}
+
+
+void Stopwatch::render()
+{
+   if (!(al_is_system_installed()))
+      {
+         std::stringstream error_message;
+         error_message << "Stopwatch" << "::" << "render" << ": error: " << "guard \"al_is_system_installed()\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   if (!(al_is_font_addon_initialized()))
+      {
+         std::stringstream error_message;
+         error_message << "Stopwatch" << "::" << "render" << ": error: " << "guard \"al_is_font_addon_initialized()\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   if (!(font_bin))
+      {
+         std::stringstream error_message;
+         error_message << "Stopwatch" << "::" << "render" << ": error: " << "guard \"font_bin\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   return;
+}
+
+ALLEGRO_FONT* Stopwatch::obtain_font()
+{
+   if (!(font_bin))
+      {
+         std::stringstream error_message;
+         error_message << "Stopwatch" << "::" << "obtain_font" << ": error: " << "guard \"font_bin\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   return font_bin->auto_get("Purista Medium.otf -32");
+}
+} // namespace Elements
+} // namespace AllegroFlare
+
+

--- a/src/AllegroFlare/Elements/Stopwatch.cpp
+++ b/src/AllegroFlare/Elements/Stopwatch.cpp
@@ -1,6 +1,8 @@
 
 
 #include <AllegroFlare/Elements/Stopwatch.hpp>
+#include <AllegroFlare/TimerFormatter.hpp>
+#include <AllegroFlare/Color.hpp>
 #include <stdexcept>
 #include <sstream>
 #include <stdexcept>
@@ -14,8 +16,9 @@ namespace Elements
 
 
 Stopwatch::Stopwatch(AllegroFlare::FontBin* font_bin)
-   : font_bin(font_bin)
-   , quote({})
+   : AllegroFlare::Elements::Base()
+   , font_bin(font_bin)
+   , timer({})
 {
 }
 
@@ -24,6 +27,30 @@ Stopwatch::~Stopwatch()
 {
 }
 
+
+void Stopwatch::start()
+{
+   timer.start();
+   return;
+}
+
+void Stopwatch::pause()
+{
+   timer.pause();
+   return;
+}
+
+void Stopwatch::reset()
+{
+   timer.reset();
+   return;
+}
+
+void Stopwatch::is_running()
+{
+   timer.is_running();
+   return;
+}
 
 void Stopwatch::render()
 {
@@ -45,6 +72,13 @@ void Stopwatch::render()
          error_message << "Stopwatch" << "::" << "render" << ": error: " << "guard \"font_bin\" not met";
          throw std::runtime_error(error_message.str());
       }
+   ALLEGRO_COLOR color = AllegroFlare::Color::White;
+   ALLEGRO_FONT *font = obtain_font();
+   std::string ellapsed_time_str = AllegroFlare::TimerFormatter(timer.get_elapsed_time_milliseconds()).format();
+
+   get_placement_ref().start_transform();
+   al_draw_text(font, color, 0, 0, ALLEGRO_ALIGN_LEFT, ellapsed_time_str.c_str());
+   get_placement_ref().restore_transform();
    return;
 }
 
@@ -56,7 +90,7 @@ ALLEGRO_FONT* Stopwatch::obtain_font()
          error_message << "Stopwatch" << "::" << "obtain_font" << ": error: " << "guard \"font_bin\" not met";
          throw std::runtime_error(error_message.str());
       }
-   return font_bin->auto_get("Purista Medium.otf -32");
+   return font_bin->auto_get("DroidSans.ttf -74");
 }
 } // namespace Elements
 } // namespace AllegroFlare

--- a/src/AllegroFlare/Elements/Stopwatch.cpp
+++ b/src/AllegroFlare/Elements/Stopwatch.cpp
@@ -1,6 +1,8 @@
 
 
 #include <AllegroFlare/Elements/Stopwatch.hpp>
+#include <stdexcept>
+#include <sstream>
 #include <AllegroFlare/TimerFormatter.hpp>
 #include <stdexcept>
 #include <sstream>
@@ -61,6 +63,34 @@ void Stopwatch::reset()
 void Stopwatch::is_running()
 {
    timer.is_running();
+   return;
+}
+
+void Stopwatch::fit_placement_width_and_height_to_stopwatch()
+{
+   if (!(al_is_system_installed()))
+      {
+         std::stringstream error_message;
+         error_message << "Stopwatch" << "::" << "fit_placement_width_and_height_to_stopwatch" << ": error: " << "guard \"al_is_system_installed()\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   if (!(al_is_font_addon_initialized()))
+      {
+         std::stringstream error_message;
+         error_message << "Stopwatch" << "::" << "fit_placement_width_and_height_to_stopwatch" << ": error: " << "guard \"al_is_font_addon_initialized()\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   if (!(font_bin))
+      {
+         std::stringstream error_message;
+         error_message << "Stopwatch" << "::" << "fit_placement_width_and_height_to_stopwatch" << ": error: " << "guard \"font_bin\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   std::string ellapsed_time_str = build_ellapsed_time_str();
+   float width = al_get_text_width(obtain_font(), ellapsed_time_str.c_str());
+   float height = al_get_font_line_height(obtain_font());
+   get_placement_ref().size.x = width;
+   get_placement_ref().size.y = height;
    return;
 }
 

--- a/src/AllegroFlare/Elements/Stopwatch.cpp
+++ b/src/AllegroFlare/Elements/Stopwatch.cpp
@@ -2,7 +2,6 @@
 
 #include <AllegroFlare/Elements/Stopwatch.hpp>
 #include <AllegroFlare/TimerFormatter.hpp>
-#include <AllegroFlare/Color.hpp>
 #include <stdexcept>
 #include <sstream>
 #include <stdexcept>
@@ -19,12 +18,25 @@ Stopwatch::Stopwatch(AllegroFlare::FontBin* font_bin)
    : AllegroFlare::Elements::Base()
    , font_bin(font_bin)
    , timer({})
+   , color(ALLEGRO_COLOR{1, 1, 1, 1})
 {
 }
 
 
 Stopwatch::~Stopwatch()
 {
+}
+
+
+void Stopwatch::set_color(ALLEGRO_COLOR color)
+{
+   this->color = color;
+}
+
+
+ALLEGRO_COLOR Stopwatch::get_color()
+{
+   return color;
 }
 
 
@@ -72,14 +84,18 @@ void Stopwatch::render()
          error_message << "Stopwatch" << "::" << "render" << ": error: " << "guard \"font_bin\" not met";
          throw std::runtime_error(error_message.str());
       }
-   ALLEGRO_COLOR color = AllegroFlare::Color::White;
    ALLEGRO_FONT *font = obtain_font();
-   std::string ellapsed_time_str = AllegroFlare::TimerFormatter(timer.get_elapsed_time_milliseconds()).format();
+   std::string ellapsed_time_str = build_ellapsed_time_str();
 
    get_placement_ref().start_transform();
    al_draw_text(font, color, 0, 0, ALLEGRO_ALIGN_LEFT, ellapsed_time_str.c_str());
    get_placement_ref().restore_transform();
    return;
+}
+
+std::string Stopwatch::build_ellapsed_time_str()
+{
+   return AllegroFlare::TimerFormatter(timer.get_elapsed_time_milliseconds()).format();
 }
 
 ALLEGRO_FONT* Stopwatch::obtain_font()

--- a/src/AllegroFlare/Testing/WithAllegroRenderingFixture.cpp
+++ b/src/AllegroFlare/Testing/WithAllegroRenderingFixture.cpp
@@ -11,6 +11,9 @@
 #include <thread>
 #include <stdexcept>
 #include <sstream>
+#include <allegro5/allegro_color.h>
+#include <stdexcept>
+#include <sstream>
 
 
 namespace AllegroFlare
@@ -140,6 +143,18 @@ AllegroFlare::Placement2D WithAllegroRenderingFixture::build_centered_placement(
       }
    AllegroFlare::Placement2D place(al_get_display_width(display)/2, al_get_display_height(display)/2, width, height);
    return place;
+}
+
+void WithAllegroRenderingFixture::draw_rulers()
+{
+   if (!(al_get_target_bitmap()))
+      {
+         std::stringstream error_message;
+         error_message << "WithAllegroRenderingFixture" << "::" << "draw_rulers" << ": error: " << "guard \"al_get_target_bitmap()\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   al_draw_line(1920/2, 0, 1920/2, 1080, al_color_name("gray"), 1.0); // rulers down the center
+   al_draw_line(0, 1080/2, 1920, 1080/2, al_color_name("gray"), 1.0); // rulers across the middle
 }
 } // namespace Testing
 } // namespace AllegroFlare

--- a/tests/AllegroFlare/Elements/StopwatchTest.cpp
+++ b/tests/AllegroFlare/Elements/StopwatchTest.cpp
@@ -7,6 +7,7 @@
    catch (...) { FAIL() << "Expected " # raised_exception_type; }
 
 #include <AllegroFlare/Testing/WithAllegroRenderingFixture.hpp>
+#include <AllegroFlare/Color.hpp>
 
 
 class AllegroFlare_Elements_StopwatchTest : public ::testing::Test
@@ -52,4 +53,23 @@ TEST_F(AllegroFlare_Elements_StopwatchTestWithAllegroRenderingFixture, render__w
    EXPECT_THROW_WITH_MESSAGE(stopwatch.render(), std::runtime_error, expected_error_message);
 }
 
+
+TEST_F(AllegroFlare_Elements_StopwatchTestWithAllegroRenderingFixture, render__will_display_the_time_on_the_timer)
+{
+   AllegroFlare::Elements::Stopwatch stopwatch(&get_font_bin_ref());
+
+   stopwatch.get_placement_ref() = build_centered_placement();
+
+   stopwatch.start();
+
+   float seconds = 2.0;
+   float fps = 60;
+   for (int frame=0; frame<(seconds * fps); frame++)
+   {
+      al_clear_to_color(AllegroFlare::Color::Eigengrau);
+      stopwatch.render();
+      al_flip_display();
+      sleep_for_frame();
+   }
+}
 

--- a/tests/AllegroFlare/Elements/StopwatchTest.cpp
+++ b/tests/AllegroFlare/Elements/StopwatchTest.cpp
@@ -1,0 +1,55 @@
+
+#include <gtest/gtest.h>
+
+#define EXPECT_THROW_WITH_MESSAGE(code, raised_exception_type, expected_exception_message) \
+   try { code; FAIL() << "Expected " # raised_exception_type; } \
+   catch ( raised_exception_type const &err ) { EXPECT_EQ(std::string(expected_exception_message), err.what()); } \
+   catch (...) { FAIL() << "Expected " # raised_exception_type; }
+
+#include <AllegroFlare/Testing/WithAllegroRenderingFixture.hpp>
+
+
+class AllegroFlare_Elements_StopwatchTest : public ::testing::Test
+{};
+
+class AllegroFlare_Elements_StopwatchTestWithAllegroRenderingFixture
+   : public AllegroFlare::Testing::WithAllegroRenderingFixture
+{};
+
+
+#include <AllegroFlare/Elements/Stopwatch.hpp>
+
+
+TEST_F(AllegroFlare_Elements_StopwatchTest, can_be_created_without_blowing_up)
+{
+   AllegroFlare::Elements::Stopwatch stopwatch;
+}
+
+
+TEST_F(AllegroFlare_Elements_StopwatchTest, render__without_allegro_initialized__raises_an_error)
+{
+   AllegroFlare::Elements::Stopwatch stopwatch;
+   std::string expected_error_message =
+      "Stopwatch::render: error: guard \"al_is_system_installed()\" not met";
+   EXPECT_THROW_WITH_MESSAGE(stopwatch.render(), std::runtime_error, expected_error_message);
+}
+
+
+TEST_F(AllegroFlare_Elements_StopwatchTest, render__without_font_addon_initialized__raises_an_error)
+{
+   al_init();
+   AllegroFlare::Elements::Stopwatch stopwatch;
+   std::string expected_error_message = "Stopwatch::render: error: guard \"al_is_font_addon_initialized()\" not met";
+   EXPECT_THROW_WITH_MESSAGE(stopwatch.render(), std::runtime_error, expected_error_message);
+   al_uninstall_system();
+}
+
+
+TEST_F(AllegroFlare_Elements_StopwatchTestWithAllegroRenderingFixture, render__without_a_font_bin__will_raise_an_error)
+{
+   AllegroFlare::Elements::Stopwatch stopwatch;
+   std::string expected_error_message = "Stopwatch::render: error: guard \"font_bin\" not met";
+   EXPECT_THROW_WITH_MESSAGE(stopwatch.render(), std::runtime_error, expected_error_message);
+}
+
+

--- a/tests/AllegroFlare/Elements/StopwatchTest.cpp
+++ b/tests/AllegroFlare/Elements/StopwatchTest.cpp
@@ -62,14 +62,14 @@ TEST_F(AllegroFlare_Elements_StopwatchTestWithAllegroRenderingFixture, render__w
 
    stopwatch.start();
 
-   float seconds = 0.1;
+   float seconds = 0.2;
    float fps = 60;
    for (int frame=0; frame<(seconds * fps); frame++)
    {
       al_clear_to_color(AllegroFlare::Color::Eigengrau);
       stopwatch.render();
       al_flip_display();
-      sleep_for_frame();
+      //sleep_for_frame();
    }
 }
 

--- a/tests/AllegroFlare/Elements/StopwatchTest.cpp
+++ b/tests/AllegroFlare/Elements/StopwatchTest.cpp
@@ -62,7 +62,7 @@ TEST_F(AllegroFlare_Elements_StopwatchTestWithAllegroRenderingFixture, render__w
 
    stopwatch.start();
 
-   float seconds = 2.0;
+   float seconds = 0.1;
    float fps = 60;
    for (int frame=0; frame<(seconds * fps); frame++)
    {
@@ -78,10 +78,30 @@ TEST_F(AllegroFlare_Elements_StopwatchTestWithAllegroRenderingFixture, render__w
 {
    AllegroFlare::Elements::Stopwatch stopwatch(&get_font_bin_ref());
    stopwatch.get_placement_ref() = build_centered_placement();
-   stopwatch.set_color(AllegroFlare::Color::MintCream);
+   stopwatch.set_color(AllegroFlare::Color::Aquamarine);
 
    al_clear_to_color(AllegroFlare::Color::Eigengrau);
    stopwatch.render();
    al_flip_display();
+
+   //sleep_for(1);
 }
+
+
+TEST_F(AllegroFlare_Elements_StopwatchTestWithAllegroRenderingFixture,
+  fit_placement_width_and_height_to_stopwatch__will_set_the_placement_width_and_height_to_fit_the_stopwatch_text)
+{
+   AllegroFlare::Elements::Stopwatch stopwatch(&get_font_bin_ref());
+   stopwatch.get_placement_ref() = build_centered_placement();
+   stopwatch.fit_placement_width_and_height_to_stopwatch();
+
+   al_clear_to_color(AllegroFlare::Color::Eigengrau);
+   stopwatch.render();
+   stopwatch.get_placement_ref().draw_box(AllegroFlare::Color::MintCream);
+   draw_rulers();
+   al_flip_display();
+
+   //sleep_for(1);
+}
+
 

--- a/tests/AllegroFlare/Elements/StopwatchTest.cpp
+++ b/tests/AllegroFlare/Elements/StopwatchTest.cpp
@@ -73,3 +73,15 @@ TEST_F(AllegroFlare_Elements_StopwatchTestWithAllegroRenderingFixture, render__w
    }
 }
 
+
+TEST_F(AllegroFlare_Elements_StopwatchTestWithAllegroRenderingFixture, render__will_display_the_timer_colored)
+{
+   AllegroFlare::Elements::Stopwatch stopwatch(&get_font_bin_ref());
+   stopwatch.get_placement_ref() = build_centered_placement();
+   stopwatch.set_color(AllegroFlare::Color::MintCream);
+
+   al_clear_to_color(AllegroFlare::Color::Eigengrau);
+   stopwatch.render();
+   al_flip_display();
+}
+


### PR DESCRIPTION
This PR adds a basic `Elements/Stopwatch`.  It derives from `Elements/Base`.

![AllegroFlare_Elements_StopwatchTestWithAllegroRend](https://user-images.githubusercontent.com/772949/175095880-fdaeec17-281e-4cdc-8027-3b86919d45df.png)

At this time, though there isn't a way to set the timer's _font_.  It's currently set internally but you need to pass in a `FontBin`.  I'm not sure what the design strategy is going to be here.