### PR TITLE
Integrate Achievements

### DIFF
--- a/examples/AllegroFlare/AchievementsExample.cpp
+++ b/examples/AllegroFlare/AchievementsExample.cpp
@@ -33,7 +33,7 @@ public:
       return player_inventory.get_item_count(ITEM_BARLEY) >= 10;
    }
 
-   void on_achieved() override
+   void on_unlocked() override
    {
       std::cout << "Congratulations! You've got 10 bundles of barley! Epic!" << std::endl;
       std::cout << std::flush;

--- a/include/AllegroFlare/Achievement.hpp
+++ b/include/AllegroFlare/Achievement.hpp
@@ -12,6 +12,7 @@ namespace AllegroFlare
       Achievement();
       virtual ~Achievement();
 
+      bool virtual unlock_manually() final;
       bool is_achieved();
       bool virtual test_condition();
       void virtual on_achieved();

--- a/include/AllegroFlare/Achievement.hpp
+++ b/include/AllegroFlare/Achievement.hpp
@@ -6,16 +6,16 @@ namespace AllegroFlare
    class Achievement
    {
    private:
-      bool achieved;
+      bool unlocked;
 
    public:
       Achievement();
       virtual ~Achievement();
 
       bool virtual unlock_manually() final;
-      bool is_achieved();
+      bool is_unlocked();
       bool virtual test_condition();
-      void virtual on_achieved();
+      void virtual on_unlocked();
    };
 }
 

--- a/include/AllegroFlare/Achievements.hpp
+++ b/include/AllegroFlare/Achievements.hpp
@@ -2,6 +2,7 @@
 
 
 #include <AllegroFlare/Achievement.hpp>
+#include <AllegroFlare/EventEmitter.hpp>
 #include <string>
 #include <map>
 
@@ -12,9 +13,10 @@ namespace AllegroFlare
    {
    private:
       std::map<std::string, std::pair<Achievement *, bool>> all_achievements;
+      EventEmitter *event_emitter;
 
    public:
-      Achievements();
+      Achievements(EventEmitter *event_emitter=nullptr);
       ~Achievements();
 
       void add(std::string name, Achievement *achievement);
@@ -22,6 +24,8 @@ namespace AllegroFlare
       int get_num_achievements();
       void clear_all();
       bool all_achieved();
+
+      void set_event_emitter(EventEmitter *event_emitter=nullptr);
    };
 }
 

--- a/include/AllegroFlare/Achievements.hpp
+++ b/include/AllegroFlare/Achievements.hpp
@@ -27,6 +27,7 @@ namespace AllegroFlare
       bool unlock_manually(std::string name);
 
       void set_event_emitter(EventEmitter *event_emitter=nullptr);
+      std::string dump();
    };
 }
 

--- a/include/AllegroFlare/Achievements.hpp
+++ b/include/AllegroFlare/Achievements.hpp
@@ -24,6 +24,7 @@ namespace AllegroFlare
       int get_num_achievements();
       void clear_all();
       bool all_achieved();
+      bool unlock_manually(std::string name);
 
       void set_event_emitter(EventEmitter *event_emitter=nullptr);
    };

--- a/include/AllegroFlare/Achievements.hpp
+++ b/include/AllegroFlare/Achievements.hpp
@@ -23,7 +23,7 @@ namespace AllegroFlare
       void check_all();
       int get_num_achievements();
       void clear_all();
-      bool all_achieved();
+      bool all_unlocked();
       bool unlock_manually(std::string name);
 
       void set_event_emitter(EventEmitter *event_emitter=nullptr);

--- a/include/AllegroFlare/Achievements.hpp
+++ b/include/AllegroFlare/Achievements.hpp
@@ -14,6 +14,7 @@ namespace AllegroFlare
    private:
       std::map<std::string, std::pair<Achievement *, bool>> all_achievements;
       EventEmitter *event_emitter;
+      bool unlock(std::pair<Achievement *, bool> *achievement);
 
    public:
       Achievements(EventEmitter *event_emitter=nullptr);

--- a/include/AllegroFlare/EventNames.hpp
+++ b/include/AllegroFlare/EventNames.hpp
@@ -26,6 +26,7 @@
 #define ALLEGRO_FLARE_EVENT_GAME_EVENT                  ALLEGRO_GET_EVENT_TYPE('F','E','G','E')
 
 // User's Events in their game
+#define ALLEGRO_FLARE_EVENT_UNLOCK_ACHIEVEMENT          ALLEGRO_GET_EVENT_TYPE('F','U','l','A')
 #define ALLEGRO_FLARE_EVENT_ACHIEVEMENT_UNLOCKED        ALLEGRO_GET_EVENT_TYPE('F','A','c','U')
 
 // Consider:

--- a/include/AllegroFlare/EventNames.hpp
+++ b/include/AllegroFlare/EventNames.hpp
@@ -25,6 +25,9 @@
 // User's Events in their game
 #define ALLEGRO_FLARE_EVENT_GAME_EVENT                  ALLEGRO_GET_EVENT_TYPE('F','E','G','E')
 
+// User's Events in their game
+#define ALLEGRO_FLARE_EVENT_ACHIEVEMENT_UNLOCKED        ALLEGRO_GET_EVENT_TYPE('F','A','c','U')
+
 // Consider:
 // { 
 //    std::string event_identifier

--- a/include/AllegroFlare/Frameworks/Full.hpp
+++ b/include/AllegroFlare/Frameworks/Full.hpp
@@ -13,6 +13,7 @@
 #include <AllegroFlare/Display.hpp>
 #include <AllegroFlare/Motion.hpp>
 #include <AllegroFlare/ScreenManagers/Dictionary.hpp>
+#include <AllegroFlare/Achievements.hpp>
 #include <AllegroFlare/AudioController.hpp>
 #include <AllegroFlare/EventEmitter.hpp>
 #include <AllegroFlare/VirtualControlsProcessor.hpp>
@@ -35,6 +36,7 @@ namespace AllegroFlare
          ModelBin models;
          Motion motions;
          AudioController audio_controller;
+         Achievements achievements;
          EventEmitter event_emitter;
          VirtualControlsProcessor virtual_controls_processor;
          ALLEGRO_TEXTLOG *textlog;
@@ -84,6 +86,9 @@ namespace AllegroFlare
          void register_screen(std::string name, AllegroFlare::Screens::Basic *screen);
          void unregister_screen(AllegroFlare::Screens::Basic *screen);
          void activate_screen(std::string name);
+
+         void register_achievement(std::string name, Achievement *achievement);
+         void unregister_achievement(Achievement *achievement); // NOT IMPLEMENTED
 
          Display *create_display(int width=1280, int height=720);
          Display *create_display(int width, int height, int display_flags);

--- a/include/AllegroFlare/Frameworks/Full.hpp
+++ b/include/AllegroFlare/Frameworks/Full.hpp
@@ -36,8 +36,8 @@ namespace AllegroFlare
          ModelBin models;
          Motion motions;
          AudioController audio_controller;
-         Achievements achievements;
          EventEmitter event_emitter;
+         Achievements achievements;
          VirtualControlsProcessor virtual_controls_processor;
          ALLEGRO_TEXTLOG *textlog;
          ALLEGRO_JOYSTICK *joystick; // this needs some updating to allow for multiple joysticks

--- a/src/AllegroFlare/Achievement.cpp
+++ b/src/AllegroFlare/Achievement.cpp
@@ -13,6 +13,16 @@ namespace AllegroFlare
    {}
 
 
+
+   bool Achievement::unlock_manually()
+   {
+      if (achieved) return false;
+
+      achieved = true;
+      on_achieved();
+      return true;
+   }
+
    bool Achievement::is_achieved() { return achieved; }
 
 

--- a/src/AllegroFlare/Achievement.cpp
+++ b/src/AllegroFlare/Achievement.cpp
@@ -5,7 +5,7 @@
 namespace AllegroFlare
 {
    Achievement::Achievement()
-      : achieved(false)
+      : unlocked(false)
    {}
 
 
@@ -16,20 +16,20 @@ namespace AllegroFlare
 
    bool Achievement::unlock_manually()
    {
-      if (achieved) return false;
+      if (unlocked) return false;
 
-      achieved = true;
-      on_achieved();
+      unlocked = true;
+      on_unlocked();
       return true;
    }
 
-   bool Achievement::is_achieved() { return achieved; }
+   bool Achievement::is_unlocked() { return unlocked; }
 
 
    bool Achievement::test_condition() { return false; }
 
 
-   void Achievement::on_achieved() {}
+   void Achievement::on_unlocked() {}
 }
 
 

--- a/src/AllegroFlare/Achievements.cpp
+++ b/src/AllegroFlare/Achievements.cpp
@@ -64,7 +64,7 @@ namespace AllegroFlare
       all_achievements.clear();
    }
 
-   bool Achievements::all_achieved()
+   bool Achievements::all_unlocked()
    {
       for (auto &achievement : all_achievements)
       {
@@ -87,7 +87,7 @@ namespace AllegroFlare
 
       std::pair<Achievement *, bool> &achievement = it->second;
 
-      achievement.first->on_achieved();
+      achievement.first->on_unlocked();
       achievement.second = true;
       if (event_emitter)
       {

--- a/src/AllegroFlare/Achievements.cpp
+++ b/src/AllegroFlare/Achievements.cpp
@@ -3,13 +3,15 @@
 #include <AllegroFlare/Achievements.hpp>
 
 
+#include <AllegroFlare/EventNames.hpp>
 #include <iostream>
 
 
 namespace AllegroFlare
 {
-   Achievements::Achievements()
+   Achievements::Achievements(EventEmitter *event_emitter)
       : all_achievements({})
+      , event_emitter(event_emitter)
    {}
 
 
@@ -37,6 +39,12 @@ namespace AllegroFlare
          {
             achievement.second.first->on_achieved();
             achievement.second.second = true;
+            if (event_emitter)
+            {
+               // TODO: add test for this case
+               Achievement* completed_achievement = achievement.second.first;
+               event_emitter->emit_event(ALLEGRO_FLARE_EVENT_ACHIEVEMENT_UNLOCKED, (intptr_t)completed_achievement);
+            }
          }
       }
    }
@@ -58,6 +66,11 @@ namespace AllegroFlare
          if (!achievement.second.second) return false;
       }
       return true;
+   }
+
+   void Achievements::set_event_emitter(EventEmitter *event_emitter)
+   {
+      this->event_emitter = event_emitter;
    }
 }
 

--- a/src/AllegroFlare/Achievements.cpp
+++ b/src/AllegroFlare/Achievements.cpp
@@ -18,9 +18,9 @@ namespace AllegroFlare
 
    Achievements::~Achievements()
    {
-      for (auto &achievement : all_achievements)
-         delete achievement.second.first;
-      all_achievements.clear();
+      //for (auto &achievement : all_achievements)
+      //   delete achievement.second.first;
+      //all_achievements.clear();
    }
 
 
@@ -100,6 +100,20 @@ namespace AllegroFlare
    void Achievements::set_event_emitter(EventEmitter *event_emitter)
    {
       this->event_emitter = event_emitter;
+   }
+
+   std::string Achievements::dump()
+   {
+      std::stringstream result;
+      for (auto &achievement : all_achievements)
+      {
+         result << "achievement: \""
+                << achievement.first
+                << "\", unlocked: "
+                << (achievement.second.second ? "true" : "false")
+                << std::endl;
+      }
+      return result.str();
    }
 }
 

--- a/src/AllegroFlare/Achievements.cpp
+++ b/src/AllegroFlare/Achievements.cpp
@@ -5,6 +5,7 @@
 
 #include <AllegroFlare/EventNames.hpp>
 #include <iostream>
+#include <sstream>
 
 
 namespace AllegroFlare
@@ -25,6 +26,7 @@ namespace AllegroFlare
 
    void Achievements::add(std::string name, Achievement *achievement)
    {
+      // TODO: check for overwrite
       all_achievements[name].first = achievement;
       all_achievements[name].second = false;
    }
@@ -37,14 +39,15 @@ namespace AllegroFlare
          bool achievement_already_unlocked = achievement.second.second;
          if (!achievement_already_unlocked && achievement.second.first->test_condition())
          {
-            achievement.second.first->on_achieved();
-            achievement.second.second = true;
-            if (event_emitter)
-            {
-               // TODO: add test for this case
-               Achievement* completed_achievement = achievement.second.first;
-               event_emitter->emit_event(ALLEGRO_FLARE_EVENT_ACHIEVEMENT_UNLOCKED, (intptr_t)completed_achievement);
-            }
+            unlock_manually(achievement.first);
+            //achievement.second.first->on_achieved();
+            //achievement.second.second = true;
+            //if (event_emitter)
+            //{
+               //// TODO: add test for this case
+               //Achievement* completed_achievement = achievement.second.first;
+               //event_emitter->emit_event(ALLEGRO_FLARE_EVENT_ACHIEVEMENT_UNLOCKED, (intptr_t)completed_achievement);
+            //}
          }
       }
    }
@@ -66,6 +69,30 @@ namespace AllegroFlare
          if (!achievement.second.second) return false;
       }
       return true;
+   }
+
+   bool Achievements::unlock_manually(std::string name)
+   {
+      std::map<std::string, std::pair<Achievement *, bool>>::iterator it = all_achievements.find(name);
+      if (it == all_achievements.end())
+      {
+         std::stringstream ss;
+         ss << "[Achievements::unlock_manually] error: Could not find achievement named \""
+            << name << "\"";
+         std::cout << ss.str();
+         return false;
+      }
+
+      std::pair<Achievement *, bool> &achievement = it->second;
+
+      achievement.first->on_achieved();
+      achievement.second = true;
+      if (event_emitter)
+      {
+         // TODO: add test for this case
+         Achievement* completed_achievement = achievement.first;
+         event_emitter->emit_event(ALLEGRO_FLARE_EVENT_ACHIEVEMENT_UNLOCKED, (intptr_t)completed_achievement);
+      }
    }
 
    void Achievements::set_event_emitter(EventEmitter *event_emitter)

--- a/src/AllegroFlare/Achievements.cpp
+++ b/src/AllegroFlare/Achievements.cpp
@@ -87,13 +87,21 @@ namespace AllegroFlare
 
       std::pair<Achievement *, bool> &achievement = it->second;
 
-      achievement.first->on_unlocked();
-      achievement.second = true;
-      if (event_emitter)
+      if (achievement.second == true)
       {
-         // TODO: add test for this case
-         Achievement* completed_achievement = achievement.first;
-         event_emitter->emit_event(ALLEGRO_FLARE_EVENT_ACHIEVEMENT_UNLOCKED, (intptr_t)completed_achievement);
+         // TODO: consider outputting a message
+         return false;
+      }
+      else
+      {
+         achievement.first->on_unlocked();
+         achievement.second = true;
+         if (event_emitter)
+         {
+            Achievement* completed_achievement = achievement.first;
+            event_emitter->emit_event(ALLEGRO_FLARE_EVENT_ACHIEVEMENT_UNLOCKED, (intptr_t)completed_achievement);
+         }
+         return true;
       }
    }
 

--- a/src/AllegroFlare/Achievements.cpp
+++ b/src/AllegroFlare/Achievements.cpp
@@ -24,6 +24,32 @@ namespace AllegroFlare
    }
 
 
+   bool Achievements::unlock(std::pair<Achievement *, bool> *achievement)
+   {
+      if (!achievement)
+      {
+         // TODO: errors
+      }
+
+      if (achievement->second == true)
+      {
+         // TODO: consider outputting a message
+         return false;
+      }
+      else
+      {
+         achievement->first->on_unlocked();
+         achievement->second = true;
+         if (event_emitter)
+         {
+            Achievement* completed_achievement = achievement->first;
+            event_emitter->emit_event(ALLEGRO_FLARE_EVENT_ACHIEVEMENT_UNLOCKED, (intptr_t)completed_achievement);
+         }
+         return true;
+      }
+   }
+
+
    void Achievements::add(std::string name, Achievement *achievement)
    {
       // TODO: check for overwrite
@@ -39,30 +65,23 @@ namespace AllegroFlare
          bool achievement_already_unlocked = achievement.second.second;
          if (!achievement_already_unlocked && achievement.second.first->test_condition())
          {
-            // TODO: clean this up a bit and add tests
-            unlock_manually(achievement.first);
-
-            //achievement.second.first->on_achieved();
-            //achievement.second.second = true;
-            //if (event_emitter)
-            //{
-               //// TODO: add test for this case
-               //Achievement* completed_achievement = achievement.second.first;
-               //event_emitter->emit_event(ALLEGRO_FLARE_EVENT_ACHIEVEMENT_UNLOCKED, (intptr_t)completed_achievement);
-            //}
+            unlock(&achievement.second);
          }
       }
    }
+
 
    int Achievements::get_num_achievements()
    {
       return all_achievements.size();
    }
 
+
    void Achievements::clear_all()
    {
       all_achievements.clear();
    }
+
 
    bool Achievements::all_unlocked()
    {
@@ -72,6 +91,7 @@ namespace AllegroFlare
       }
       return true;
    }
+
 
    bool Achievements::unlock_manually(std::string name)
    {
@@ -87,28 +107,15 @@ namespace AllegroFlare
 
       std::pair<Achievement *, bool> &achievement = it->second;
 
-      if (achievement.second == true)
-      {
-         // TODO: consider outputting a message
-         return false;
-      }
-      else
-      {
-         achievement.first->on_unlocked();
-         achievement.second = true;
-         if (event_emitter)
-         {
-            Achievement* completed_achievement = achievement.first;
-            event_emitter->emit_event(ALLEGRO_FLARE_EVENT_ACHIEVEMENT_UNLOCKED, (intptr_t)completed_achievement);
-         }
-         return true;
-      }
+      return unlock(&achievement);
    }
+
 
    void Achievements::set_event_emitter(EventEmitter *event_emitter)
    {
       this->event_emitter = event_emitter;
    }
+
 
    std::string Achievements::dump()
    {

--- a/src/AllegroFlare/Achievements.cpp
+++ b/src/AllegroFlare/Achievements.cpp
@@ -17,11 +17,7 @@ namespace AllegroFlare
 
 
    Achievements::~Achievements()
-   {
-      //for (auto &achievement : all_achievements)
-      //   delete achievement.second.first;
-      //all_achievements.clear();
-   }
+   {}
 
 
    bool Achievements::unlock(std::pair<Achievement *, bool> *achievement)

--- a/src/AllegroFlare/Achievements.cpp
+++ b/src/AllegroFlare/Achievements.cpp
@@ -39,7 +39,9 @@ namespace AllegroFlare
          bool achievement_already_unlocked = achievement.second.second;
          if (!achievement_already_unlocked && achievement.second.first->test_condition())
          {
+            // TODO: clean this up a bit and add tests
             unlock_manually(achievement.first);
+
             //achievement.second.first->on_achieved();
             //achievement.second.second = true;
             //if (event_emitter)

--- a/src/AllegroFlare/Frameworks/Full.cpp
+++ b/src/AllegroFlare/Frameworks/Full.cpp
@@ -38,8 +38,8 @@ Full::Full()
    , models()
    , motions(200)
    , audio_controller(&samples)
-   , achievements()
    , event_emitter()
+   , achievements()
    , virtual_controls_processor()
    , textlog(nullptr)
    , joystick(nullptr)
@@ -186,6 +186,8 @@ bool Full::initialize_without_display()
 
    virtual_controls_processor.set_event_emitter(&event_emitter);
    virtual_controls_processor.initialize();
+
+   achievements.set_event_emitter(&event_emitter);
 
    //if (al_get_num_joysticks()) joystick = al_get_joystick(0); // make this better eventually
    //else

--- a/src/AllegroFlare/Frameworks/Full.cpp
+++ b/src/AllegroFlare/Frameworks/Full.cpp
@@ -38,6 +38,7 @@ Full::Full()
    , models()
    , motions(200)
    , audio_controller(&samples)
+   , achievements()
    , event_emitter()
    , virtual_controls_processor()
    , textlog(nullptr)
@@ -284,6 +285,19 @@ void Full::activate_screen(std::string name)
 }
 
 
+void Full::register_achievement(std::string name, Achievement *achievement)
+{
+   achievements.add(name, achievement);
+}
+
+
+void Full::unregister_achievement(Achievement *achievement)
+{
+   throw std::runtime_error("Frameworks::Full::unregister: error: not implemented");
+   // TODO: not implemented
+}
+
+
 Display *Full::create_display(int width, int height)
 {
    return create_display(width, height, false, -1);
@@ -406,7 +420,7 @@ void Full::run_loop()
 
       current_event = &this_event;
       time_now = this_event.any.timestamp;
-      motions.update(time_now);
+      //motions.update(time_now); // this was here, and has been moved to below the ALLEGRO_EVENT_TIMER event
 
       screens.on_events(current_event);
 
@@ -415,6 +429,11 @@ void Full::run_loop()
       case ALLEGRO_EVENT_TIMER:
          if (this_event.timer.source == primary_timer)
          {
+            // update
+            motions.update(time_now);
+            achievements.check_all();
+
+            // render
             al_clear_to_color(ALLEGRO_COLOR{0, 0, 0, 0});
             screens.primary_timer_funcs();
             al_flip_display();
@@ -562,6 +581,10 @@ void Full::run_loop()
                           delete data;
                        }
                     }
+                  break;
+
+                  case ALLEGRO_FLARE_EVENT_ACHIEVEMENT_UNLOCKED:
+                    // TODO figure out what to do here
                   break;
                }
             }

--- a/src/AllegroFlare/Frameworks/Full.cpp
+++ b/src/AllegroFlare/Frameworks/Full.cpp
@@ -588,6 +588,22 @@ void Full::run_loop()
                   case ALLEGRO_FLARE_EVENT_ACHIEVEMENT_UNLOCKED:
                     // TODO figure out what to do here
                   break;
+
+                  case ALLEGRO_FLARE_EVENT_UNLOCK_ACHIEVEMENT:
+                     {
+                        std::string *data = (std::string *)this_event.user.data1;
+                        if (!data)
+                        {
+                           // TODO: add an error message
+                        }
+                        else
+                        {
+                           achievements.unlock_manually(*data);
+                           //audio_controller.play_music_track_by_identifier(*data);
+                           delete data;
+                        }
+                     }
+                  break;
                }
             }
             else

--- a/tests/AllegroFlare/AchievementTest.cpp
+++ b/tests/AllegroFlare/AchievementTest.cpp
@@ -1,0 +1,43 @@
+
+
+
+#include <gtest/gtest.h>
+
+#include <AllegroFlare/Achievement.hpp>
+
+
+TEST(AchievementTest, can_be_created_without_arguments)
+{
+   AllegroFlare::Achievement achievements;
+}
+
+
+TEST(AchievementTest, achieved__is_initialized_to_false)
+{
+   AllegroFlare::Achievement achievements;
+   EXPECT_EQ(false, achievements.is_achieved());
+}
+
+
+TEST(AchievementTest, unlock_manually__will_unlock_the_achievement_and_return_true)
+{
+   AllegroFlare::Achievement achievements;
+   EXPECT_EQ(true, achievements.unlock_manually());
+   EXPECT_EQ(true, achievements.is_achieved());
+}
+
+
+TEST(AchievementTest, unlock_manually__will_call_the_achievements_on_achieved_method)
+{
+   // TODO: this test
+}
+
+
+TEST(AchievementTest, unlock_manually__if_already_unlocked__will_do_nothing_and_return_false)
+{
+   AllegroFlare::Achievement achievements;
+   EXPECT_EQ(true, achievements.unlock_manually());
+   EXPECT_EQ(false, achievements.unlock_manually());
+}
+
+

--- a/tests/AllegroFlare/AchievementTest.cpp
+++ b/tests/AllegroFlare/AchievementTest.cpp
@@ -12,10 +12,10 @@ TEST(AchievementTest, can_be_created_without_arguments)
 }
 
 
-TEST(AchievementTest, achieved__is_initialized_to_false)
+TEST(AchievementTest, unlocked__is_initialized_to_false)
 {
    AllegroFlare::Achievement achievements;
-   EXPECT_EQ(false, achievements.is_achieved());
+   EXPECT_EQ(false, achievements.is_unlocked());
 }
 
 
@@ -23,11 +23,11 @@ TEST(AchievementTest, unlock_manually__will_unlock_the_achievement_and_return_tr
 {
    AllegroFlare::Achievement achievements;
    EXPECT_EQ(true, achievements.unlock_manually());
-   EXPECT_EQ(true, achievements.is_achieved());
+   EXPECT_EQ(true, achievements.is_unlocked());
 }
 
 
-TEST(AchievementTest, unlock_manually__will_call_the_achievements_on_achieved_method)
+TEST(AchievementTest, unlock_manually__will_call_the_achievements_on_unlocked_method)
 {
    // TODO: this test
 }

--- a/tests/AllegroFlare/AchievementsTest.cpp
+++ b/tests/AllegroFlare/AchievementsTest.cpp
@@ -12,3 +12,27 @@ TEST(AchievementsTest, can_be_created_without_arguments)
 }
 
 
+TEST(AchievementsTest, unlock_manually__will_mark_the_achievement_as_unlocked)
+{
+   // TODO
+}
+
+
+TEST(AchievementsTest, unlock_manually__will_mark_____raises_an_error)
+{
+   // TODO
+}
+
+
+TEST(AchievementsTest, unlock_manually__when_the_named_achievement_does_not_exist__raises_an_error)
+{
+   // TODO
+}
+
+
+TEST(AchievementsTest, unlock_manually__when_the_achievement_has_already_been_unlocked__does_nothing_and_returns_false)
+{
+   // TODO
+}
+
+

--- a/tests/AllegroFlare/AchievementsTest.cpp
+++ b/tests/AllegroFlare/AchievementsTest.cpp
@@ -12,4 +12,3 @@ TEST(AchievementsTest, can_be_created_without_arguments)
 }
 
 
-

--- a/tests/AllegroFlare/AchievementsTest.cpp
+++ b/tests/AllegroFlare/AchievementsTest.cpp
@@ -30,13 +30,14 @@ TEST(AchievementsTest, add__will_add_the_achievement_to_the_list)
 }
 
 
-TEST(AchievementsTest, unlock_manually__will_mark_the_achievement_as_unlocked_in_the_list_and_on_the_object)
+TEST(AchievementsTest,
+   unlock_manually__will_mark_the_achievement_as_unlocked_in_the_list_and_on_the_object_and_return_true)
 {
    AllegroFlare::Achievements achievements;
    AchievementTestClass achievement;
    achievements.add("my_achievement", &achievement);
 
-   achievements.unlock_manually("my_achievement");
+   EXPECT_EQ(true, achievements.unlock_manually("my_achievement"));
 
    std::string expected_dump_string = "achievement: \"my_achievement\", unlocked: true\n";
    std::string actual_dump_string = achievements.dump();
@@ -61,7 +62,12 @@ TEST(AchievementsTest,
 
 TEST(AchievementsTest, unlock_manually__when_the_achievement_has_already_been_unlocked__does_nothing_and_returns_false)
 {
-   // TODO
+   AllegroFlare::Achievements achievements;
+   AchievementTestClass achievement;
+   achievements.add("my_achievement", &achievement);
+
+   achievements.unlock_manually("my_achievement");
+   EXPECT_EQ(false, achievements.unlock_manually("my_achievement"));
 }
 
 

--- a/tests/AllegroFlare/AchievementsTest.cpp
+++ b/tests/AllegroFlare/AchievementsTest.cpp
@@ -6,27 +6,56 @@
 #include <AllegroFlare/Achievements.hpp>
 
 
+class AchievementTestClass : public AllegroFlare::Achievement
+{};
+
+
+
 TEST(AchievementsTest, can_be_created_without_arguments)
 {
    AllegroFlare::Achievements achievements;
 }
 
 
-TEST(AchievementsTest, unlock_manually__will_mark_the_achievement_as_unlocked)
+TEST(AchievementsTest, add__will_add_the_achievement_to_the_list)
 {
-   // TODO
+   AllegroFlare::Achievements achievements;
+   AchievementTestClass achievement;
+
+   achievements.add("my_achievement", &achievement);
+
+   std::string expected_dump_string = "achievement: \"my_achievement\", unlocked: false\n";
+   std::string actual_dump_string = achievements.dump();
+   EXPECT_EQ(expected_dump_string, actual_dump_string);
 }
 
 
-TEST(AchievementsTest, unlock_manually__will_mark_____raises_an_error)
+TEST(AchievementsTest, unlock_manually__will_mark_the_achievement_as_unlocked_in_the_list_and_on_the_object)
 {
-   // TODO
+   AllegroFlare::Achievements achievements;
+   AchievementTestClass achievement;
+   achievements.add("my_achievement", &achievement);
+
+   achievements.unlock_manually("my_achievement");
+
+   std::string expected_dump_string = "achievement: \"my_achievement\", unlocked: true\n";
+   std::string actual_dump_string = achievements.dump();
+   EXPECT_EQ(expected_dump_string, actual_dump_string);
 }
 
 
-TEST(AchievementsTest, unlock_manually__when_the_named_achievement_does_not_exist__raises_an_error)
+TEST(AchievementsTest,
+   unlock_manually__when_the_named_achievement_does_not_exist__will_output_an_error_message_to_cout)
 {
-   // TODO
+   AllegroFlare::Achievements achievements;
+   testing::internal::CaptureStdout();
+
+   achievements.unlock_manually("an-achievement-name-that-does-not-exist");
+
+   std::string expected_cout_output = "[Achievements::unlock_manually] error: Could not find "
+                                      "achievement named \"an-achievement-name-that-does-not-exist\"";
+   std::string actual_cout_output = testing::internal::GetCapturedStdout();
+   EXPECT_EQ(expected_cout_output, actual_cout_output);
 }
 
 


### PR DESCRIPTION
## Problem

See [issue](https://github.com/allegroflare/allegro_flare/issues/192).

## Solution

This PR adds the `Achievements` system into the `Frameworks::Full`.  In this implementation, all unlocked achievements are evaluated on the primary timer tick.

## Some Caveats

* Each achievement may have a complex query required to be evaluated. If that's the case, then the Achievement should schedule its own evaluation, and then set a flag internally so the achievement can be evaluated by the system.
* Achievements may need to be "activated" or "deactivated".  For example, a level that unlocks an area after you light 3 torches may only need to be evaluated in the context of that level.  It may also need to be reset upon re-entering the level.  In this case, achievements operate as a slightly different way, or, this would be a different type of logic - a different type of component.  That is something to consider.
* Achievements may rely on pointers or references to objects that have not been created.  Achievements are conceptually added at load time, so this is an unclarified concern.  It's possible that Achievements could be created at load time, but its referenced objects that are injected internally could remain `nullptr` until the objects are created in the level, only then to be set in the Achievement.  The pointers would need to be removed when a level is shutdown which could be an issue.
* Events are evaluated every frame. If you wanted to have a mechanism that unlocked an achievement via an event (e.g. `event_emitter.emit(UNLOCK_ACHIEVEMENT, "my_achievement_name");`, that system is currently not implemented. (I'm going to add that now, [added here](https://github.com/allegroflare/allegro_flare/pull/204/commits/511f6bf1038ce872cb84f483243c45b41f418f33)).

Fixes https://github.com/allegroflare/allegro_flare/issues/192