### PR TITLE
Add UnicodeFontViewer

### DIFF
--- a/documentation/dependents.json
+++ b/documentation/dependents.json
@@ -162,6 +162,9 @@
     "AllegroFlare/Screens/TitleScreen",
     "AllegroFlare/Useful3D/Triangle"
   ],
+  "AllegroFlare/FontAwesome": [
+    "AllegroFlare/Elements/HealthBars/Hearts"
+  ],
   "int32_t": [
     "AllegroFlare/Elements/HealthBars/Hearts"
   ],

--- a/documentation/dependents.json
+++ b/documentation/dependents.json
@@ -62,7 +62,8 @@
     "AllegroFlare/Screens/TitleScreen",
     "AllegroFlare/StoryboardFactory",
     "AllegroFlare/StoryboardPageFactory",
-    "AllegroFlare/Testing/WithAllegroRenderingFixture"
+    "AllegroFlare/Testing/WithAllegroRenderingFixture",
+    "AllegroFlare/UnicodeFontViewer"
   ],
   "ALLEGRO_FONT": [
     "AllegroFlare/Bone3DGraphRenderer",
@@ -78,7 +79,8 @@
     "AllegroFlare/Screens/GameWonScreen",
     "AllegroFlare/Screens/Storyboard",
     "AllegroFlare/Screens/TitleScreen",
-    "AllegroFlare/Testing/WithAllegroRenderingFixture"
+    "AllegroFlare/Testing/WithAllegroRenderingFixture",
+    "AllegroFlare/UnicodeFontViewer"
   ],
   "al_is_system_installed": [
     "AllegroFlare/Bone3DGraphRenderer"
@@ -89,7 +91,8 @@
     "AllegroFlare/Elements/HealthBars/Hearts"
   ],
   "al_is_font_addon_initialized": [
-    "AllegroFlare/Bone3DGraphRenderer"
+    "AllegroFlare/Bone3DGraphRenderer",
+    "AllegroFlare/UnicodeFontViewer"
   ],
   "AllegroFlare/draw_3d_line": [
     "AllegroFlare/Bone3DGraphRenderer"
@@ -160,10 +163,8 @@
     "AllegroFlare/Elements/Text",
     "AllegroFlare/Screens/Storyboard",
     "AllegroFlare/Screens/TitleScreen",
+    "AllegroFlare/UnicodeFontViewer",
     "AllegroFlare/Useful3D/Triangle"
-  ],
-  "AllegroFlare/FontAwesome": [
-    "AllegroFlare/Elements/HealthBars/Hearts"
   ],
   "int32_t": [
     "AllegroFlare/Elements/HealthBars/Hearts"
@@ -194,7 +195,8 @@
     "AllegroFlare/Elements/StoryboardPages/AdvancingText",
     "AllegroFlare/Elements/StoryboardPages/Image",
     "AllegroFlare/Elements/StoryboardPages/Text",
-    "AllegroFlare/Screens/Storyboard"
+    "AllegroFlare/Screens/Storyboard",
+    "AllegroFlare/UnicodeFontViewer"
   ],
   "AllegroFlare/interpolator": [
     "AllegroFlare/Elements/Inventory",
@@ -382,6 +384,9 @@
   ],
   "std/time_t": [
     "AllegroFlare/TimeStamper"
+  ],
+  "al_is_ttf_addon_initialized": [
+    "AllegroFlare/UnicodeFontViewer"
   ],
   "cross_product": [
     "AllegroFlare/Useful3D/Triangle"

--- a/documentation/dependents.json
+++ b/documentation/dependents.json
@@ -88,7 +88,8 @@
   "al_is_primitives_addon_initialized": [
     "AllegroFlare/Bone3DGraphRenderer",
     "AllegroFlare/Elements/HealthBars/Classic",
-    "AllegroFlare/Elements/HealthBars/Hearts"
+    "AllegroFlare/Elements/HealthBars/Hearts",
+    "AllegroFlare/UnicodeFontViewer"
   ],
   "al_is_font_addon_initialized": [
     "AllegroFlare/Bone3DGraphRenderer",
@@ -385,7 +386,13 @@
   "std/time_t": [
     "AllegroFlare/TimeStamper"
   ],
+  "std/setfill": [
+    "AllegroFlare/UnicodeFontViewer"
+  ],
   "al_is_ttf_addon_initialized": [
+    "AllegroFlare/UnicodeFontViewer"
+  ],
+  "al_draw_rectangle": [
     "AllegroFlare/UnicodeFontViewer"
   ],
   "cross_product": [

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -747,6 +747,9 @@ table td
     </table>
      <table>
 <tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::FontAwesome&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/FontAwesome.hpp&quot;]}</td>
+</tr>
+<tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::FontBin*&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/FontBin.hpp&quot;]}</td>
 </tr>
 <tr>
@@ -2988,6 +2991,9 @@ table td
     "AllegroFlare/Screens/Storyboard",
     "AllegroFlare/Screens/TitleScreen",
     "AllegroFlare/Useful3D/Triangle"
+  ],
+  "AllegroFlare/FontAwesome": [
+    "AllegroFlare/Elements/HealthBars/Hearts"
   ],
   "int32_t": [
     "AllegroFlare/Elements/HealthBars/Hearts"

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -2537,6 +2537,10 @@ table td
   <td class="property">AllegroFlare::FontBin*</td>
 </tr>
 <tr>
+  <td class="property">font_identifier</td>
+  <td class="property">std::string</td>
+</tr>
+<tr>
   <td class="property">unicode_range_start</td>
   <td class="property">int32_t</td>
 </tr>

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -2542,7 +2542,7 @@ table td
 </tr>
 <tr>
   <td class="property">unicode_range_start</td>
-  <td class="property">int32_t</td>
+  <td class="property">uint32_t</td>
 </tr>
     </table>
      <table>
@@ -2554,6 +2554,12 @@ table td
 </tr>
 <tr>
   <td class="method">next_page()</td>
+</tr>
+<tr>
+  <td class="method">as_hex(2)</td>
+</tr>
+<tr>
+  <td class="method">as_int(1)</td>
 </tr>
 <tr>
   <td class="private_method">draw_unicode_character(6)</td>
@@ -2569,6 +2575,9 @@ table td
 </tr>
     </table>
      <table>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;std::setfill&quot;, &quot;headers&quot;=&gt;[&quot;iomanip&quot;]}</td>
+</tr>
 <tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;ALLEGRO_COLOR&quot;, &quot;headers&quot;=&gt;[&quot;allegro5/allegro.h&quot;]}</td>
 </tr>
@@ -2586,6 +2595,12 @@ table td
 </tr>
 <tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;al_is_ttf_addon_initialized&quot;, &quot;headers&quot;=&gt;[&quot;allegro5/allegro_font.h&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;al_draw_rectangle&quot;, &quot;headers&quot;=&gt;[&quot;allegro5/allegro_primitives.h&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;al_is_primitives_addon_initialized&quot;, &quot;headers&quot;=&gt;[&quot;allegro5/allegro_primitives.h&quot;]}</td>
 </tr>
     </table>
   </div>
@@ -2978,7 +2993,8 @@ table td
   "al_is_primitives_addon_initialized": [
     "AllegroFlare/Bone3DGraphRenderer",
     "AllegroFlare/Elements/HealthBars/Classic",
-    "AllegroFlare/Elements/HealthBars/Hearts"
+    "AllegroFlare/Elements/HealthBars/Hearts",
+    "AllegroFlare/UnicodeFontViewer"
   ],
   "al_is_font_addon_initialized": [
     "AllegroFlare/Bone3DGraphRenderer",
@@ -3275,7 +3291,13 @@ table td
   "std/time_t": [
     "AllegroFlare/TimeStamper"
   ],
+  "std/setfill": [
+    "AllegroFlare/UnicodeFontViewer"
+  ],
   "al_is_ttf_addon_initialized": [
+    "AllegroFlare/UnicodeFontViewer"
+  ],
+  "al_draw_rectangle": [
     "AllegroFlare/UnicodeFontViewer"
   ],
   "cross_product": [

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -88,6 +88,7 @@ table td
   <li><a href="#quintessence/AllegroFlare/StoryboardPageFactory.q.yml">quintessence/AllegroFlare/StoryboardPageFactory.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/Testing/WithAllegroRenderingFixture.q.yml">quintessence/AllegroFlare/Testing/WithAllegroRenderingFixture.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/TimeStamper.q.yml">quintessence/AllegroFlare/TimeStamper.q.yml</a></li>
+  <li><a href="#quintessence/AllegroFlare/UnicodeFontViewer.q.yml">quintessence/AllegroFlare/UnicodeFontViewer.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/Useful3D/Triangle.q.yml">quintessence/AllegroFlare/Useful3D/Triangle.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/Vec2B.q.yml">quintessence/AllegroFlare/Vec2B.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/Vec2I.q.yml">quintessence/AllegroFlare/Vec2I.q.yml</a></li>
@@ -746,9 +747,6 @@ table td
 </tr>
     </table>
      <table>
-<tr>
-  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::FontAwesome&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/FontAwesome.hpp&quot;]}</td>
-</tr>
 <tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::FontBin*&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/FontBin.hpp&quot;]}</td>
 </tr>
@@ -2532,6 +2530,64 @@ table td
 </ul>
 <ul>
   <div class="component">
+    <h3 id="quintessence/AllegroFlare/UnicodeFontViewer.q.yml">quintessence/AllegroFlare/UnicodeFontViewer.q.yml</h3>
+     <table>
+<tr>
+  <td class="property">font_bin</td>
+  <td class="property">AllegroFlare::FontBin*</td>
+</tr>
+<tr>
+  <td class="property">unicode_range_start</td>
+  <td class="property">int32_t</td>
+</tr>
+    </table>
+     <table>
+<tr>
+  <td class="method">render()</td>
+</tr>
+<tr>
+  <td class="method">previous_page()</td>
+</tr>
+<tr>
+  <td class="method">next_page()</td>
+</tr>
+<tr>
+  <td class="private_method">draw_unicode_character(6)</td>
+</tr>
+<tr>
+  <td class="private_method">obtain_unicode_font()</td>
+</tr>
+<tr>
+  <td class="private_method">obtain_ui_font()</td>
+</tr>
+<tr>
+  <td class="private_method">obtain_ui_font_mini()</td>
+</tr>
+    </table>
+     <table>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;ALLEGRO_COLOR&quot;, &quot;headers&quot;=&gt;[&quot;allegro5/allegro.h&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;ALLEGRO_FONT*&quot;, &quot;headers&quot;=&gt;[&quot;allegro5/allegro.h&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::FontBin*&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/FontBin.hpp&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::Color&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/Color.hpp&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;al_is_font_addon_initialized&quot;, &quot;headers&quot;=&gt;[&quot;allegro5/allegro_font.h&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;al_is_ttf_addon_initialized&quot;, &quot;headers&quot;=&gt;[&quot;allegro5/allegro_font.h&quot;]}</td>
+</tr>
+    </table>
+  </div>
+</ul>
+<ul>
+  <div class="component">
     <h3 id="quintessence/AllegroFlare/Useful3D/Triangle.q.yml">quintessence/AllegroFlare/Useful3D/Triangle.q.yml</h3>
      <table>
 <tr>
@@ -2892,7 +2948,8 @@ table td
     "AllegroFlare/Screens/TitleScreen",
     "AllegroFlare/StoryboardFactory",
     "AllegroFlare/StoryboardPageFactory",
-    "AllegroFlare/Testing/WithAllegroRenderingFixture"
+    "AllegroFlare/Testing/WithAllegroRenderingFixture",
+    "AllegroFlare/UnicodeFontViewer"
   ],
   "ALLEGRO_FONT": [
     "AllegroFlare/Bone3DGraphRenderer",
@@ -2908,7 +2965,8 @@ table td
     "AllegroFlare/Screens/GameWonScreen",
     "AllegroFlare/Screens/Storyboard",
     "AllegroFlare/Screens/TitleScreen",
-    "AllegroFlare/Testing/WithAllegroRenderingFixture"
+    "AllegroFlare/Testing/WithAllegroRenderingFixture",
+    "AllegroFlare/UnicodeFontViewer"
   ],
   "al_is_system_installed": [
     "AllegroFlare/Bone3DGraphRenderer"
@@ -2919,7 +2977,8 @@ table td
     "AllegroFlare/Elements/HealthBars/Hearts"
   ],
   "al_is_font_addon_initialized": [
-    "AllegroFlare/Bone3DGraphRenderer"
+    "AllegroFlare/Bone3DGraphRenderer",
+    "AllegroFlare/UnicodeFontViewer"
   ],
   "AllegroFlare/draw_3d_line": [
     "AllegroFlare/Bone3DGraphRenderer"
@@ -2990,10 +3049,8 @@ table td
     "AllegroFlare/Elements/Text",
     "AllegroFlare/Screens/Storyboard",
     "AllegroFlare/Screens/TitleScreen",
+    "AllegroFlare/UnicodeFontViewer",
     "AllegroFlare/Useful3D/Triangle"
-  ],
-  "AllegroFlare/FontAwesome": [
-    "AllegroFlare/Elements/HealthBars/Hearts"
   ],
   "int32_t": [
     "AllegroFlare/Elements/HealthBars/Hearts"
@@ -3024,7 +3081,8 @@ table td
     "AllegroFlare/Elements/StoryboardPages/AdvancingText",
     "AllegroFlare/Elements/StoryboardPages/Image",
     "AllegroFlare/Elements/StoryboardPages/Text",
-    "AllegroFlare/Screens/Storyboard"
+    "AllegroFlare/Screens/Storyboard",
+    "AllegroFlare/UnicodeFontViewer"
   ],
   "AllegroFlare/interpolator": [
     "AllegroFlare/Elements/Inventory",
@@ -3212,6 +3270,9 @@ table td
   ],
   "std/time_t": [
     "AllegroFlare/TimeStamper"
+  ],
+  "al_is_ttf_addon_initialized": [
+    "AllegroFlare/UnicodeFontViewer"
   ],
   "cross_product": [
     "AllegroFlare/Useful3D/Triangle"

--- a/examples/AllegroFlare/FontAwesomeExample.cpp
+++ b/examples/AllegroFlare/FontAwesomeExample.cpp
@@ -13,7 +13,7 @@ private:
 public:
    FontAwesomeExample(AllegroFlare::FontBin *font_bin)
       : AllegroFlare::Screens::Base()
-      , unicode_font_viewer(font_bin, "fa-solid-900.ttf", 0xF000)
+      , unicode_font_viewer(font_bin, "fa-solid-900.ttf", 0xF000) // FontAwesome characters start in the 0xF000 range
    {}
 
    void primary_timer_func() override

--- a/examples/AllegroFlare/FontAwesomeExample.cpp
+++ b/examples/AllegroFlare/FontAwesomeExample.cpp
@@ -1,82 +1,24 @@
 
 
-#include <allegro5/allegro_font.h>
 #include <AllegroFlare/Screens/Base.hpp>
 #include <AllegroFlare/Frameworks/Full.hpp>
-#include <AllegroFlare/FontBin.hpp>
-#include <AllegroFlare/Color.hpp>
+#include <AllegroFlare/UnicodeFontViewer.hpp>
 
 
-class UnicodeFontViewerExample : public AllegroFlare::Screens::Base
+class FontAwesomeExample : public AllegroFlare::Screens::Base
 {
 private:
-   AllegroFlare::FontBin fonts;
-   std::string font_identifier_str;
-   ALLEGRO_FONT *unicode_font, *ui_font, *ui_font_mini;
-   int32_t unicode_range_start;
+   AllegroFlare::UnicodeFontViewer unicode_font_viewer;
 
 public:
-   UnicodeFontViewerExample(std::string font_identifier_str)
+   FontAwesomeExample(AllegroFlare::FontBin *font_bin)
       : AllegroFlare::Screens::Base()
-      , fonts()
-      , font_identifier_str(font_identifier_str)
-      , unicode_font(nullptr)
-      , ui_font(nullptr)
-      , ui_font_mini(nullptr)
-      , unicode_range_start(0x1D100) // bravura characters start at range -> unicode_range_start(0x1D100)
+      , unicode_font_viewer(font_bin, "fa-solid-900.ttf", 0xF000)
    {}
-
-   ~UnicodeFontViewerExample()
-   {
-      fonts.clear();
-   }
-
-   void init()
-   {
-      fonts.set_full_path("/Users/markoates/Repos/allegro_flare/bin/data/fonts");
-
-      unicode_font = fonts[font_identifier_str];
-      ui_font = fonts["Inter-Medium.ttf 20"];
-      ui_font_mini = fonts["Inter-Medium.ttf 9"];
-   }
-
-   void draw_unicode_character(ALLEGRO_FONT *font, ALLEGRO_COLOR color, int32_t icon, int flags, float x, float y)
-   {
-      static ALLEGRO_USTR *ustr = NULL;
-      if (!ustr) ustr = al_ustr_new("");
-      al_ustr_set_chr(ustr, 0, icon);
-      al_draw_ustr(font, color, x, y, flags, ustr);
-   }
 
    void primary_timer_func() override
    {
-      int32_t unicode_range_end = unicode_range_start+0x00ff;
-      ALLEGRO_COLOR white = AllegroFlare::Color::White;
-      ALLEGRO_COLOR black = AllegroFlare::Color::Black;
-      std::stringstream range_string;
-
-      range_string << "you are currently viewing the range " << unicode_range_start << "-" << unicode_range_end;
-
-      al_draw_text(ui_font, white, 20, 20, 0, "Press the RIGHT ARROW and LEFT ARROW keys to flip through the pages");
-      al_draw_text(ui_font, white, 20, 60, 0, range_string.str().c_str());
-
-      //int y=90;
-      int line = 0;
-      int num_rows = 30;
-      int line_height = 80;
-      int row_width = 45;
-      int row = 0;
-      for (int32_t character=unicode_range_start; character<=unicode_range_end; character++)
-      {
-         int x = 100 + row*row_width;
-         int y = 100 + line*line_height;
-         draw_unicode_character(unicode_font, white, character, ALLEGRO_ALIGN_CENTER, x, y);
-         std::stringstream character_number_as_str;
-         character_number_as_str << character;
-         al_draw_text(ui_font_mini, white, x, y, 0, character_number_as_str.str().c_str());
-         row += 1;
-         if (row > num_rows) { row = 0; line++; }
-      }
+      unicode_font_viewer.render();
    }
 
    void key_char_func(ALLEGRO_EVENT *ev) override
@@ -84,10 +26,10 @@ public:
       switch(ev->keyboard.keycode)
       {
       case ALLEGRO_KEY_RIGHT:
-         unicode_range_start += 0x0100;
+         unicode_font_viewer.next_page();
          break;
       case ALLEGRO_KEY_LEFT:
-         unicode_range_start -= 0x0100;
+         unicode_font_viewer.previous_page();
          break;
       }
    }
@@ -99,11 +41,13 @@ int main(int argc, char **argv)
    AllegroFlare::Frameworks::Full framework;
    framework.initialize();
 
-   UnicodeFontViewerExample unicode_font_viewer_example("fa-solid-900.ttf 40");
-   unicode_font_viewer_example.init();
-   framework.register_screen("unicode_font_viewer_example", &unicode_font_viewer_example);
+   AllegroFlare::FontBin &font_bin = framework.get_font_bin_ref();
+   font_bin.set_full_path("/Users/markoates/Repos/allegro_flare/bin/data/fonts");
 
-   framework.activate_screen("unicode_font_viewer_example");
+   FontAwesomeExample font_awesome_example(&font_bin);
+   framework.register_screen("font_awesome_example", &font_awesome_example);
+
+   framework.activate_screen("font_awesome_example");
 
    framework.run_loop();
 

--- a/examples/AllegroFlare/FontBravuraExample.cpp
+++ b/examples/AllegroFlare/FontBravuraExample.cpp
@@ -1,82 +1,24 @@
 
 
-#include <allegro5/allegro_font.h>
 #include <AllegroFlare/Screens/Base.hpp>
 #include <AllegroFlare/Frameworks/Full.hpp>
-#include <AllegroFlare/FontBin.hpp>
-#include <AllegroFlare/Color.hpp>
+#include <AllegroFlare/UnicodeFontViewer.hpp>
 
 
-class UnicodeFontViewerExample : public AllegroFlare::Screens::Base
+class FontAwesomeExample : public AllegroFlare::Screens::Base
 {
 private:
-   AllegroFlare::FontBin fonts;
-   std::string font_identifier_str;
-   ALLEGRO_FONT *unicode_font, *ui_font, *ui_font_mini;
-   int32_t unicode_range_start;
+   AllegroFlare::UnicodeFontViewer unicode_font_viewer;
 
 public:
-   UnicodeFontViewerExample(std::string font_identifier_str)
+   FontAwesomeExample(AllegroFlare::FontBin *font_bin)
       : AllegroFlare::Screens::Base()
-      , fonts()
-      , font_identifier_str(font_identifier_str)
-      , unicode_font(nullptr)
-      , ui_font(nullptr)
-      , ui_font_mini(nullptr)
-      , unicode_range_start(0x1D100) // bravura characters start at range -> unicode_range_start(0x1D100)
+      , unicode_font_viewer(font_bin, "Bravura.otf", 0x1D100) // Bravura characters start in the 0x1D100 range
    {}
-
-   ~UnicodeFontViewerExample()
-   {
-      fonts.clear();
-   }
-
-   void init()
-   {
-      fonts.set_full_path("/Users/markoates/Repos/allegro_flare/bin/data/fonts");
-
-      unicode_font = fonts[font_identifier_str];
-      ui_font = fonts["Inter-Medium.ttf 20"];
-      ui_font_mini = fonts["Inter-Medium.ttf 9"];
-   }
-
-   void draw_unicode_character(ALLEGRO_FONT *font, ALLEGRO_COLOR color, int32_t icon, int flags, float x, float y)
-   {
-      static ALLEGRO_USTR *ustr = NULL;
-      if (!ustr) ustr = al_ustr_new("");
-      al_ustr_set_chr(ustr, 0, icon);
-      al_draw_ustr(font, color, x, y, flags, ustr);
-   }
 
    void primary_timer_func() override
    {
-      int32_t unicode_range_end = unicode_range_start+0x00ff;
-      ALLEGRO_COLOR white = AllegroFlare::Color::White;
-      ALLEGRO_COLOR black = AllegroFlare::Color::Black;
-      std::stringstream range_string;
-
-      range_string << "you are currently viewing the range " << unicode_range_start << "-" << unicode_range_end;
-
-      al_draw_text(ui_font, white, 20, 20, 0, "Press the RIGHT ARROW and LEFT ARROW keys to flip through the pages");
-      al_draw_text(ui_font, white, 20, 60, 0, range_string.str().c_str());
-
-      //int y=90;
-      int line = 0;
-      int num_rows = 30;
-      int line_height = 80;
-      int row_width = 45;
-      int row = 0;
-      for (int32_t character=unicode_range_start; character<=unicode_range_end; character++)
-      {
-         int x = 100 + row*row_width;
-         int y = 100 + line*line_height;
-         draw_unicode_character(unicode_font, white, character, ALLEGRO_ALIGN_CENTER, x, y);
-         std::stringstream character_number_as_str;
-         character_number_as_str << character;
-         al_draw_text(ui_font_mini, white, x, y, 0, character_number_as_str.str().c_str());
-         row += 1;
-         if (row > num_rows) { row = 0; line++; }
-      }
+      unicode_font_viewer.render();
    }
 
    void key_char_func(ALLEGRO_EVENT *ev) override
@@ -84,10 +26,10 @@ public:
       switch(ev->keyboard.keycode)
       {
       case ALLEGRO_KEY_RIGHT:
-         unicode_range_start += 0x0100;
+         unicode_font_viewer.next_page();
          break;
       case ALLEGRO_KEY_LEFT:
-         unicode_range_start -= 0x0100;
+         unicode_font_viewer.previous_page();
          break;
       }
    }
@@ -99,15 +41,18 @@ int main(int argc, char **argv)
    AllegroFlare::Frameworks::Full framework;
    framework.initialize();
 
-   UnicodeFontViewerExample unicode_font_viewer_example("Bravura.otf 40");
-   unicode_font_viewer_example.init();
-   framework.register_screen("unicode_font_viewer_example", &unicode_font_viewer_example);
+   AllegroFlare::FontBin &font_bin = framework.get_font_bin_ref();
+   font_bin.set_full_path("/Users/markoates/Repos/allegro_flare/bin/data/fonts");
 
-   framework.activate_screen("unicode_font_viewer_example");
+   FontAwesomeExample font_bravura_example(&font_bin);
+   framework.register_screen("font_bravura_example", &font_bravura_example);
+
+   framework.activate_screen("font_bravura_example");
 
    framework.run_loop();
 
    return 0;
 }
+
 
 

--- a/include/AllegroFlare/UnicodeFontViewer.hpp
+++ b/include/AllegroFlare/UnicodeFontViewer.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+
+#include <string>
+
+
+namespace AllegroFlare
+{
+   class UnicodeFontViewer
+   {
+   private:
+
+   public:
+      UnicodeFontViewer();
+      ~UnicodeFontViewer();
+
+      std::string run();
+   };
+}
+
+
+

--- a/include/AllegroFlare/UnicodeFontViewer.hpp
+++ b/include/AllegroFlare/UnicodeFontViewer.hpp
@@ -4,6 +4,7 @@
 #include <AllegroFlare/FontBin.hpp>
 #include <allegro5/allegro.h>
 #include <cstdint>
+#include <string>
 
 
 namespace AllegroFlare
@@ -12,13 +13,18 @@ namespace AllegroFlare
    {
    private:
       AllegroFlare::FontBin* font_bin;
+      std::string font_identifier;
       int32_t unicode_range_start;
 
    public:
-      UnicodeFontViewer(AllegroFlare::FontBin* font_bin=nullptr);
+      UnicodeFontViewer(AllegroFlare::FontBin* font_bin=nullptr, std::string font_identifier="fa-solid-900.ttf", int32_t unicode_range_start=0x1D100);
       ~UnicodeFontViewer();
 
       void set_font_bin(AllegroFlare::FontBin* font_bin);
+      void set_font_identifier(std::string font_identifier);
+      void set_unicode_range_start(int32_t unicode_range_start);
+      std::string get_font_identifier();
+      int32_t get_unicode_range_start();
       void render();
       void previous_page();
       void next_page();

--- a/include/AllegroFlare/UnicodeFontViewer.hpp
+++ b/include/AllegroFlare/UnicodeFontViewer.hpp
@@ -14,21 +14,23 @@ namespace AllegroFlare
    private:
       AllegroFlare::FontBin* font_bin;
       std::string font_identifier;
-      int32_t unicode_range_start;
+      uint32_t unicode_range_start;
 
    public:
-      UnicodeFontViewer(AllegroFlare::FontBin* font_bin=nullptr, std::string font_identifier="fa-solid-900.ttf", int32_t unicode_range_start=0x1D100);
+      UnicodeFontViewer(AllegroFlare::FontBin* font_bin=nullptr, std::string font_identifier="fa-solid-900.ttf", uint32_t unicode_range_start=0x1D100);
       ~UnicodeFontViewer();
 
       void set_font_bin(AllegroFlare::FontBin* font_bin);
       void set_font_identifier(std::string font_identifier);
-      void set_unicode_range_start(int32_t unicode_range_start);
+      void set_unicode_range_start(uint32_t unicode_range_start);
       std::string get_font_identifier();
-      int32_t get_unicode_range_start();
+      uint32_t get_unicode_range_start();
       void render();
       void previous_page();
       void next_page();
-      void draw_unicode_character(ALLEGRO_FONT* font=nullptr, ALLEGRO_COLOR color=ALLEGRO_COLOR{1, 1, 1, 1}, int32_t icon=61444, int flags=0, float x=0.0f, float y=0.0f);
+      std::string as_hex(uint32_t value=0, int zero_fill_width=6);
+      std::string as_int(uint32_t value=0);
+      void draw_unicode_character(ALLEGRO_FONT* font=nullptr, ALLEGRO_COLOR color=ALLEGRO_COLOR{1, 1, 1, 1}, uint32_t icon=61444, int flags=0, float x=0.0f, float y=0.0f);
       ALLEGRO_FONT* obtain_unicode_font();
       ALLEGRO_FONT* obtain_ui_font();
       ALLEGRO_FONT* obtain_ui_font_mini();

--- a/include/AllegroFlare/UnicodeFontViewer.hpp
+++ b/include/AllegroFlare/UnicodeFontViewer.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 
-#include <string>
+#include <AllegroFlare/FontBin.hpp>
+#include <allegro5/allegro.h>
+#include <cstdint>
 
 
 namespace AllegroFlare
@@ -9,12 +11,21 @@ namespace AllegroFlare
    class UnicodeFontViewer
    {
    private:
+      AllegroFlare::FontBin* font_bin;
+      int32_t unicode_range_start;
 
    public:
-      UnicodeFontViewer();
+      UnicodeFontViewer(AllegroFlare::FontBin* font_bin=nullptr);
       ~UnicodeFontViewer();
 
-      std::string run();
+      void set_font_bin(AllegroFlare::FontBin* font_bin);
+      void render();
+      void previous_page();
+      void next_page();
+      void draw_unicode_character(ALLEGRO_FONT* font=nullptr, ALLEGRO_COLOR color=ALLEGRO_COLOR{1, 1, 1, 1}, int32_t icon=61444, int flags=0, float x=0.0f, float y=0.0f);
+      ALLEGRO_FONT* obtain_unicode_font();
+      ALLEGRO_FONT* obtain_ui_font();
+      ALLEGRO_FONT* obtain_ui_font_mini();
    };
 }
 

--- a/quintessence/AllegroFlare/UnicodeFontViewer.q.yml
+++ b/quintessence/AllegroFlare/UnicodeFontViewer.q.yml
@@ -1,0 +1,4 @@
+functions:
+  - name: run
+    type: std::string
+    body: return "Hello World!";

--- a/quintessence/AllegroFlare/UnicodeFontViewer.q.yml
+++ b/quintessence/AllegroFlare/UnicodeFontViewer.q.yml
@@ -1,4 +1,139 @@
+properties:
+
+
+  - name: font_bin
+    type: AllegroFlare::FontBin*
+    init_with: nullptr
+    constructor_arg: true
+    setter: true
+
+  - name: unicode_range_start
+    type: int32_t
+    init_with: 0x1D100
+
+
 functions:
-  - name: run
-    type: std::string
-    body: return "Hello World!";
+
+
+  - name: render
+    guards: [ al_is_system_installed(), al_is_font_addon_initialized(), al_is_ttf_addon_initialized(), font_bin ]
+    body: |
+      int32_t unicode_range_end = unicode_range_start+0x00ff;
+      ALLEGRO_FONT *ui_font = obtain_ui_font();
+      ALLEGRO_FONT *ui_font_mini = obtain_ui_font_mini();
+      ALLEGRO_FONT *unicode_font = obtain_unicode_font();
+      ALLEGRO_COLOR white = AllegroFlare::Color::White;
+      ALLEGRO_COLOR black = AllegroFlare::Color::Black;
+      std::stringstream range_string;
+
+      range_string << "you are currently viewing the range " << unicode_range_start << "-" << unicode_range_end;
+
+      al_draw_text(ui_font, white, 20, 20, 0, "Press the RIGHT ARROW and LEFT ARROW keys to flip through the pages");
+      al_draw_text(ui_font, white, 20, 60, 0, range_string.str().c_str());
+
+      //int y=90;
+      int line = 0;
+      int num_rows = 30;
+      int line_height = 80;
+      int row_width = 45;
+      int row = 0;
+      for (int32_t character=unicode_range_start; character<=unicode_range_end; character++)
+      {
+         int x = 100 + row*row_width;
+         int y = 100 + line*line_height;
+         draw_unicode_character(unicode_font, white, character, ALLEGRO_ALIGN_CENTER, x, y);
+         std::stringstream character_number_as_str;
+         character_number_as_str << character;
+         al_draw_text(ui_font_mini, white, x, y, 0, character_number_as_str.str().c_str());
+         row += 1;
+         if (row > num_rows) { row = 0; line++; }
+      }
+    body_dependency_symbols:
+      - AllegroFlare::Color
+      - al_is_font_addon_initialized
+      - al_is_ttf_addon_initialized
+
+
+  - name: previous_page
+    body: |
+      unicode_range_start -= 0x0100;
+      return;
+
+
+  - name: next_page
+    body: |
+      unicode_range_start += 0x0100;
+      return;
+
+
+  - name: draw_unicode_character
+    private: true
+    parameters:
+      - name: font
+        type: ALLEGRO_FONT*
+        default_argument: nullptr
+      - name: color
+        type: ALLEGRO_COLOR
+        default_argument: 'ALLEGRO_COLOR{1, 1, 1, 1}'
+      - name: icon
+        type: int32_t
+        default_argument: 61444
+      - name: flags
+        type: int
+        default_argument: 0
+      - name: x
+        type: float
+        default_argument: 0.0f
+      - name: y
+        type: float
+        default_argument: 0.0f
+    body: |
+      static ALLEGRO_USTR *ustr = NULL;
+      if (!ustr) ustr = al_ustr_new("");
+      al_ustr_set_chr(ustr, 0, icon);
+      al_draw_ustr(font, color, x, y, flags, ustr);
+      return;
+
+
+  - name: obtain_unicode_font
+    private: true
+    type: ALLEGRO_FONT*
+    guards: [ font_bin ]
+    body: |
+      return font_bin->auto_get("fa-solid-900.ttf 40");
+
+
+  - name: obtain_ui_font
+    private: true
+    type: ALLEGRO_FONT*
+    guards: [ font_bin ]
+    body: |
+      return font_bin->auto_get("Inter-Medium.ttf 20");
+
+
+  - name: obtain_ui_font_mini
+    private: true
+    type: ALLEGRO_FONT*
+    guards: [ font_bin ]
+    body: |
+      return font_bin->auto_get("Inter-Medium.ttf 9");
+
+
+dependencies:
+
+
+  - symbol: ALLEGRO_COLOR
+    headers: [ allegro5/allegro.h ]
+  - symbol: ALLEGRO_FONT*
+    headers: [ allegro5/allegro.h ]
+  - symbol: AllegroFlare::FontBin*
+    headers: [ AllegroFlare/FontBin.hpp ]
+  - symbol: AllegroFlare::Color
+    headers: [ AllegroFlare/Color.hpp ]
+  - symbol: al_is_font_addon_initialized
+    headers: [ allegro5/allegro_font.h ]
+  - symbol: al_is_ttf_addon_initialized
+    headers: [ allegro5/allegro_font.h ]
+
+
+

--- a/quintessence/AllegroFlare/UnicodeFontViewer.q.yml
+++ b/quintessence/AllegroFlare/UnicodeFontViewer.q.yml
@@ -15,7 +15,7 @@ properties:
     setter: true
 
   - name: unicode_range_start
-    type: int32_t
+    type: uint32_t
     init_with: 0x1D100
     constructor_arg: true
     getter: true
@@ -26,49 +26,80 @@ functions:
 
 
   - name: render
-    guards: [ al_is_system_installed(), al_is_font_addon_initialized(), al_is_ttf_addon_initialized(), font_bin ]
+    guards:
+      - al_is_system_installed()
+      - al_is_font_addon_initialized()
+      - al_is_ttf_addon_initialized()
+      - al_is_primitives_addon_initialized()
+      - font_bin
     body: |
-      int32_t unicode_range_end = unicode_range_start+0x00ff; // unicode_range_start to unicode_range_start+255
+      uint32_t unicode_range_end = unicode_range_start+0x00ff; // unicode_range_start to unicode_range_start+255
       ALLEGRO_FONT *ui_font = obtain_ui_font();
       ALLEGRO_FONT *ui_font_mini = obtain_ui_font_mini();
       ALLEGRO_FONT *unicode_font = obtain_unicode_font();
       ALLEGRO_COLOR white = AllegroFlare::Color::White;
       ALLEGRO_COLOR black = AllegroFlare::Color::Black;
       std::stringstream range_string;
+      int font_line_height = al_get_font_line_height(unicode_font);
+      int h_font_line_height_int = (int)(font_line_height * 0.5);
+      int ui_font_mini_line_height = al_get_font_line_height(ui_font_mini);
 
-      range_string << "you are currently viewing the range " << unicode_range_start << "-" << unicode_range_end;
+      range_string << "you are currently viewing the range "
+                   << as_hex(unicode_range_start)
+                   << "-"
+                   << as_hex(unicode_range_end)
+                   ;
 
       al_draw_text(ui_font, white, 20, 20, 0, "Press the RIGHT ARROW and LEFT ARROW keys to flip through the pages");
       al_draw_text(ui_font, white, 20, 60, 0, range_string.str().c_str());
 
-      int table_y = 180;
+      int table_y = 120;
       int table_x = 100;
       int line = 0;
       int num_columns = 32;
 
-      int line_height = 80;
-      int column_width = 52;
+      int row_height = 112;
+      int column_width = 54;
 
-      int row = 0;
-      for (int32_t character=unicode_range_start; character<=unicode_range_end; character++)
+      int column = 0;
+      for (uint32_t character=unicode_range_start; character<=unicode_range_end; character++)
       {
-         int x = table_x + row*column_width;
-         int y = table_y + line*line_height;
+         int x = table_x + column*column_width;
+         int y = table_y + line*row_height;
          float column_middle_int = (int)(x + column_width*0.5);
 
-         draw_unicode_character(unicode_font, white, character, ALLEGRO_ALIGN_CENTER, x, y);
+         al_draw_rectangle(x, y, x+column_width, y+row_height, ALLEGRO_COLOR{0.2, 0.2, 0.2, 0.2}, 1.0);
 
-         std::stringstream character_number_as_str;
-         character_number_as_str << character;
-         al_draw_text(ui_font_mini, white, column_middle_int, y, 0, character_number_as_str.str().c_str());
+         draw_unicode_character(unicode_font, white, character, ALLEGRO_ALIGN_CENTER, column_middle_int, y);
 
-         row += 1;
-         if (row > num_columns) { row = 0; line++; }
+         // draw hex number
+         al_draw_text(
+            ui_font_mini,
+            white,
+            column_middle_int,
+            y+row_height-ui_font_mini_line_height - 4,
+            ALLEGRO_ALIGN_CENTER,
+            as_hex(character).c_str()
+         );
+
+         // draw int number
+         al_draw_text(
+            ui_font_mini,
+            white,
+            column_middle_int,
+            y+row_height-(ui_font_mini_line_height*2) - 4,
+            ALLEGRO_ALIGN_CENTER,
+            as_int(character).c_str()
+         );
+
+         column += 1;
+         if (column >= num_columns) { column = 0; line++; }
       }
     body_dependency_symbols:
       - AllegroFlare::Color
       - al_is_font_addon_initialized
       - al_is_ttf_addon_initialized
+      - al_draw_rectangle
 
 
   - name: previous_page
@@ -83,6 +114,39 @@ functions:
       return;
 
 
+  - name: as_hex
+    parameters:
+      - name: value
+        type: uint32_t
+        default_argument: 0
+      - name: zero_fill_width
+        type: int
+        default_argument: 6
+    type: std::string
+    body: |
+       std::stringstream ss;
+       ss << "0x" << std::uppercase << std::setfill('0') << std::setw(zero_fill_width) << std::hex << value;
+       return ss.str();
+    body_dependency_symbols:
+      - std::stringstream
+      - std::setfill
+
+
+  - name: as_int
+    parameters:
+      - name: value
+        type: uint32_t
+        default_argument: 0
+    type: std::string
+    body: |
+       std::stringstream ss;
+       ss << value;
+       return ss.str();
+    body_dependency_symbols:
+      - std::stringstream
+      - std::setfill
+
+
   - name: draw_unicode_character
     private: true
     parameters:
@@ -93,7 +157,7 @@ functions:
         type: ALLEGRO_COLOR
         default_argument: 'ALLEGRO_COLOR{1, 1, 1, 1}'
       - name: icon
-        type: int32_t
+        type: uint32_t
         default_argument: 61444
       - name: flags
         type: int
@@ -135,12 +199,14 @@ functions:
     type: ALLEGRO_FONT*
     guards: [ font_bin ]
     body: |
-      return font_bin->auto_get("Inter-Medium.ttf 9");
+      return font_bin->auto_get("Inter-Medium.ttf 10");
 
 
 dependencies:
 
 
+  - symbol: std::setfill
+    headers: [ iomanip ]
   - symbol: ALLEGRO_COLOR
     headers: [ allegro5/allegro.h ]
   - symbol: ALLEGRO_FONT*
@@ -153,6 +219,10 @@ dependencies:
     headers: [ allegro5/allegro_font.h ]
   - symbol: al_is_ttf_addon_initialized
     headers: [ allegro5/allegro_font.h ]
+  - symbol: al_draw_rectangle
+    headers: [ allegro5/allegro_primitives.h ]
+  - symbol: al_is_primitives_addon_initialized
+    headers: [ allegro5/allegro_primitives.h ]
 
 
 

--- a/quintessence/AllegroFlare/UnicodeFontViewer.q.yml
+++ b/quintessence/AllegroFlare/UnicodeFontViewer.q.yml
@@ -7,9 +7,19 @@ properties:
     constructor_arg: true
     setter: true
 
+  - name: font_identifier
+    type: std::string
+    init_with: '"fa-solid-900.ttf"'
+    constructor_arg: true
+    getter: true
+    setter: true
+
   - name: unicode_range_start
     type: int32_t
     init_with: 0x1D100
+    constructor_arg: true
+    getter: true
+    setter: true
 
 
 functions:
@@ -18,7 +28,7 @@ functions:
   - name: render
     guards: [ al_is_system_installed(), al_is_font_addon_initialized(), al_is_ttf_addon_initialized(), font_bin ]
     body: |
-      int32_t unicode_range_end = unicode_range_start+0x00ff;
+      int32_t unicode_range_end = unicode_range_start+0x00ff; // unicode_range_start to unicode_range_start+255
       ALLEGRO_FONT *ui_font = obtain_ui_font();
       ALLEGRO_FONT *ui_font_mini = obtain_ui_font_mini();
       ALLEGRO_FONT *unicode_font = obtain_unicode_font();
@@ -31,22 +41,29 @@ functions:
       al_draw_text(ui_font, white, 20, 20, 0, "Press the RIGHT ARROW and LEFT ARROW keys to flip through the pages");
       al_draw_text(ui_font, white, 20, 60, 0, range_string.str().c_str());
 
-      //int y=90;
+      int table_y = 180;
+      int table_x = 100;
       int line = 0;
-      int num_rows = 30;
+      int num_columns = 32;
+
       int line_height = 80;
-      int row_width = 45;
+      int column_width = 52;
+
       int row = 0;
       for (int32_t character=unicode_range_start; character<=unicode_range_end; character++)
       {
-         int x = 100 + row*row_width;
-         int y = 100 + line*line_height;
+         int x = table_x + row*column_width;
+         int y = table_y + line*line_height;
+         float column_middle_int = (int)(x + column_width*0.5);
+
          draw_unicode_character(unicode_font, white, character, ALLEGRO_ALIGN_CENTER, x, y);
+
          std::stringstream character_number_as_str;
          character_number_as_str << character;
-         al_draw_text(ui_font_mini, white, x, y, 0, character_number_as_str.str().c_str());
+         al_draw_text(ui_font_mini, white, column_middle_int, y, 0, character_number_as_str.str().c_str());
+
          row += 1;
-         if (row > num_rows) { row = 0; line++; }
+         if (row > num_columns) { row = 0; line++; }
       }
     body_dependency_symbols:
       - AllegroFlare::Color
@@ -56,7 +73,7 @@ functions:
 
   - name: previous_page
     body: |
-      unicode_range_start -= 0x0100;
+      unicode_range_start -= 0x0100; // 256 characters per page
       return;
 
 
@@ -100,7 +117,9 @@ functions:
     type: ALLEGRO_FONT*
     guards: [ font_bin ]
     body: |
-      return font_bin->auto_get("fa-solid-900.ttf 40");
+      std::stringstream font_identifier_and_size;
+      font_identifier_and_size << font_identifier << " 42";
+      return font_bin->auto_get(font_identifier_and_size.str().c_str());
 
 
   - name: obtain_ui_font

--- a/src/AllegroFlare/UnicodeFontViewer.cpp
+++ b/src/AllegroFlare/UnicodeFontViewer.cpp
@@ -18,9 +18,10 @@ namespace AllegroFlare
 {
 
 
-UnicodeFontViewer::UnicodeFontViewer(AllegroFlare::FontBin* font_bin)
+UnicodeFontViewer::UnicodeFontViewer(AllegroFlare::FontBin* font_bin, std::string font_identifier, int32_t unicode_range_start)
    : font_bin(font_bin)
-   , unicode_range_start(0x1D100)
+   , font_identifier(font_identifier)
+   , unicode_range_start(unicode_range_start)
 {
 }
 
@@ -33,6 +34,30 @@ UnicodeFontViewer::~UnicodeFontViewer()
 void UnicodeFontViewer::set_font_bin(AllegroFlare::FontBin* font_bin)
 {
    this->font_bin = font_bin;
+}
+
+
+void UnicodeFontViewer::set_font_identifier(std::string font_identifier)
+{
+   this->font_identifier = font_identifier;
+}
+
+
+void UnicodeFontViewer::set_unicode_range_start(int32_t unicode_range_start)
+{
+   this->unicode_range_start = unicode_range_start;
+}
+
+
+std::string UnicodeFontViewer::get_font_identifier()
+{
+   return font_identifier;
+}
+
+
+int32_t UnicodeFontViewer::get_unicode_range_start()
+{
+   return unicode_range_start;
 }
 
 
@@ -62,7 +87,7 @@ void UnicodeFontViewer::render()
          error_message << "UnicodeFontViewer" << "::" << "render" << ": error: " << "guard \"font_bin\" not met";
          throw std::runtime_error(error_message.str());
       }
-   int32_t unicode_range_end = unicode_range_start+0x00ff;
+   int32_t unicode_range_end = unicode_range_start+0x00ff; // unicode_range_start to unicode_range_start+255
    ALLEGRO_FONT *ui_font = obtain_ui_font();
    ALLEGRO_FONT *ui_font_mini = obtain_ui_font_mini();
    ALLEGRO_FONT *unicode_font = obtain_unicode_font();
@@ -75,28 +100,35 @@ void UnicodeFontViewer::render()
    al_draw_text(ui_font, white, 20, 20, 0, "Press the RIGHT ARROW and LEFT ARROW keys to flip through the pages");
    al_draw_text(ui_font, white, 20, 60, 0, range_string.str().c_str());
 
-   //int y=90;
+   int table_y = 180;
+   int table_x = 100;
    int line = 0;
-   int num_rows = 30;
+   int num_columns = 32;
+
    int line_height = 80;
-   int row_width = 45;
+   int column_width = 52;
+
    int row = 0;
    for (int32_t character=unicode_range_start; character<=unicode_range_end; character++)
    {
-      int x = 100 + row*row_width;
-      int y = 100 + line*line_height;
+      int x = table_x + row*column_width;
+      int y = table_y + line*line_height;
+      float column_middle_int = (int)(x + column_width*0.5);
+
       draw_unicode_character(unicode_font, white, character, ALLEGRO_ALIGN_CENTER, x, y);
+
       std::stringstream character_number_as_str;
       character_number_as_str << character;
-      al_draw_text(ui_font_mini, white, x, y, 0, character_number_as_str.str().c_str());
+      al_draw_text(ui_font_mini, white, column_middle_int, y, 0, character_number_as_str.str().c_str());
+
       row += 1;
-      if (row > num_rows) { row = 0; line++; }
+      if (row > num_columns) { row = 0; line++; }
    }
 }
 
 void UnicodeFontViewer::previous_page()
 {
-   unicode_range_start -= 0x0100;
+   unicode_range_start -= 0x0100; // 256 characters per page
    return;
 }
 
@@ -123,7 +155,9 @@ ALLEGRO_FONT* UnicodeFontViewer::obtain_unicode_font()
          error_message << "UnicodeFontViewer" << "::" << "obtain_unicode_font" << ": error: " << "guard \"font_bin\" not met";
          throw std::runtime_error(error_message.str());
       }
-   return font_bin->auto_get("fa-solid-900.ttf 40");
+   std::stringstream font_identifier_and_size;
+   font_identifier_and_size << font_identifier << " 42";
+   return font_bin->auto_get(font_identifier_and_size.str().c_str());
 }
 
 ALLEGRO_FONT* UnicodeFontViewer::obtain_ui_font()

--- a/src/AllegroFlare/UnicodeFontViewer.cpp
+++ b/src/AllegroFlare/UnicodeFontViewer.cpp
@@ -4,8 +4,13 @@
 #include <AllegroFlare/Color.hpp>
 #include <allegro5/allegro_font.h>
 #include <allegro5/allegro_font.h>
+#include <allegro5/allegro_primitives.h>
 #include <stdexcept>
 #include <sstream>
+#include <sstream>
+#include <iomanip>
+#include <sstream>
+#include <iomanip>
 #include <stdexcept>
 #include <sstream>
 #include <stdexcept>
@@ -18,7 +23,7 @@ namespace AllegroFlare
 {
 
 
-UnicodeFontViewer::UnicodeFontViewer(AllegroFlare::FontBin* font_bin, std::string font_identifier, int32_t unicode_range_start)
+UnicodeFontViewer::UnicodeFontViewer(AllegroFlare::FontBin* font_bin, std::string font_identifier, uint32_t unicode_range_start)
    : font_bin(font_bin)
    , font_identifier(font_identifier)
    , unicode_range_start(unicode_range_start)
@@ -43,7 +48,7 @@ void UnicodeFontViewer::set_font_identifier(std::string font_identifier)
 }
 
 
-void UnicodeFontViewer::set_unicode_range_start(int32_t unicode_range_start)
+void UnicodeFontViewer::set_unicode_range_start(uint32_t unicode_range_start)
 {
    this->unicode_range_start = unicode_range_start;
 }
@@ -55,7 +60,7 @@ std::string UnicodeFontViewer::get_font_identifier()
 }
 
 
-int32_t UnicodeFontViewer::get_unicode_range_start()
+uint32_t UnicodeFontViewer::get_unicode_range_start()
 {
    return unicode_range_start;
 }
@@ -81,48 +86,79 @@ void UnicodeFontViewer::render()
          error_message << "UnicodeFontViewer" << "::" << "render" << ": error: " << "guard \"al_is_ttf_addon_initialized()\" not met";
          throw std::runtime_error(error_message.str());
       }
+   if (!(al_is_primitives_addon_initialized()))
+      {
+         std::stringstream error_message;
+         error_message << "UnicodeFontViewer" << "::" << "render" << ": error: " << "guard \"al_is_primitives_addon_initialized()\" not met";
+         throw std::runtime_error(error_message.str());
+      }
    if (!(font_bin))
       {
          std::stringstream error_message;
          error_message << "UnicodeFontViewer" << "::" << "render" << ": error: " << "guard \"font_bin\" not met";
          throw std::runtime_error(error_message.str());
       }
-   int32_t unicode_range_end = unicode_range_start+0x00ff; // unicode_range_start to unicode_range_start+255
+   uint32_t unicode_range_end = unicode_range_start+0x00ff; // unicode_range_start to unicode_range_start+255
    ALLEGRO_FONT *ui_font = obtain_ui_font();
    ALLEGRO_FONT *ui_font_mini = obtain_ui_font_mini();
    ALLEGRO_FONT *unicode_font = obtain_unicode_font();
    ALLEGRO_COLOR white = AllegroFlare::Color::White;
    ALLEGRO_COLOR black = AllegroFlare::Color::Black;
    std::stringstream range_string;
+   int font_line_height = al_get_font_line_height(unicode_font);
+   int h_font_line_height_int = (int)(font_line_height * 0.5);
+   int ui_font_mini_line_height = al_get_font_line_height(ui_font_mini);
 
-   range_string << "you are currently viewing the range " << unicode_range_start << "-" << unicode_range_end;
+   range_string << "you are currently viewing the range "
+                << as_hex(unicode_range_start)
+                << "-"
+                << as_hex(unicode_range_end)
+                ;
 
    al_draw_text(ui_font, white, 20, 20, 0, "Press the RIGHT ARROW and LEFT ARROW keys to flip through the pages");
    al_draw_text(ui_font, white, 20, 60, 0, range_string.str().c_str());
 
-   int table_y = 180;
+   int table_y = 120;
    int table_x = 100;
    int line = 0;
    int num_columns = 32;
 
-   int line_height = 80;
-   int column_width = 52;
+   int row_height = 112;
+   int column_width = 54;
 
-   int row = 0;
-   for (int32_t character=unicode_range_start; character<=unicode_range_end; character++)
+   int column = 0;
+   for (uint32_t character=unicode_range_start; character<=unicode_range_end; character++)
    {
-      int x = table_x + row*column_width;
-      int y = table_y + line*line_height;
+      int x = table_x + column*column_width;
+      int y = table_y + line*row_height;
       float column_middle_int = (int)(x + column_width*0.5);
 
-      draw_unicode_character(unicode_font, white, character, ALLEGRO_ALIGN_CENTER, x, y);
+      al_draw_rectangle(x, y, x+column_width, y+row_height, ALLEGRO_COLOR{0.2, 0.2, 0.2, 0.2}, 1.0);
 
-      std::stringstream character_number_as_str;
-      character_number_as_str << character;
-      al_draw_text(ui_font_mini, white, column_middle_int, y, 0, character_number_as_str.str().c_str());
+      draw_unicode_character(unicode_font, white, character, ALLEGRO_ALIGN_CENTER, column_middle_int, y);
 
-      row += 1;
-      if (row > num_columns) { row = 0; line++; }
+      // draw hex number
+      al_draw_text(
+         ui_font_mini,
+         white,
+         column_middle_int,
+         y+row_height-ui_font_mini_line_height - 4,
+         ALLEGRO_ALIGN_CENTER,
+         as_hex(character).c_str()
+      );
+
+      // draw int number
+      al_draw_text(
+         ui_font_mini,
+         white,
+         column_middle_int,
+         y+row_height-(ui_font_mini_line_height*2) - 4,
+         ALLEGRO_ALIGN_CENTER,
+         as_int(character).c_str()
+      );
+
+      column += 1;
+      if (column >= num_columns) { column = 0; line++; }
    }
 }
 
@@ -138,7 +174,21 @@ void UnicodeFontViewer::next_page()
    return;
 }
 
-void UnicodeFontViewer::draw_unicode_character(ALLEGRO_FONT* font, ALLEGRO_COLOR color, int32_t icon, int flags, float x, float y)
+std::string UnicodeFontViewer::as_hex(uint32_t value, int zero_fill_width)
+{
+   std::stringstream ss;
+   ss << "0x" << std::uppercase << std::setfill('0') << std::setw(zero_fill_width) << std::hex << value;
+   return ss.str();
+}
+
+std::string UnicodeFontViewer::as_int(uint32_t value)
+{
+   std::stringstream ss;
+   ss << value;
+   return ss.str();
+}
+
+void UnicodeFontViewer::draw_unicode_character(ALLEGRO_FONT* font, ALLEGRO_COLOR color, uint32_t icon, int flags, float x, float y)
 {
    static ALLEGRO_USTR *ustr = NULL;
    if (!ustr) ustr = al_ustr_new("");
@@ -179,7 +229,7 @@ ALLEGRO_FONT* UnicodeFontViewer::obtain_ui_font_mini()
          error_message << "UnicodeFontViewer" << "::" << "obtain_ui_font_mini" << ": error: " << "guard \"font_bin\" not met";
          throw std::runtime_error(error_message.str());
       }
-   return font_bin->auto_get("Inter-Medium.ttf 9");
+   return font_bin->auto_get("Inter-Medium.ttf 10");
 }
 } // namespace AllegroFlare
 

--- a/src/AllegroFlare/UnicodeFontViewer.cpp
+++ b/src/AllegroFlare/UnicodeFontViewer.cpp
@@ -1,14 +1,26 @@
 
 
 #include <AllegroFlare/UnicodeFontViewer.hpp>
-
+#include <AllegroFlare/Color.hpp>
+#include <allegro5/allegro_font.h>
+#include <allegro5/allegro_font.h>
+#include <stdexcept>
+#include <sstream>
+#include <stdexcept>
+#include <sstream>
+#include <stdexcept>
+#include <sstream>
+#include <stdexcept>
+#include <sstream>
 
 
 namespace AllegroFlare
 {
 
 
-UnicodeFontViewer::UnicodeFontViewer()
+UnicodeFontViewer::UnicodeFontViewer(AllegroFlare::FontBin* font_bin)
+   : font_bin(font_bin)
+   , unicode_range_start(0x1D100)
 {
 }
 
@@ -18,9 +30,122 @@ UnicodeFontViewer::~UnicodeFontViewer()
 }
 
 
-std::string UnicodeFontViewer::run()
+void UnicodeFontViewer::set_font_bin(AllegroFlare::FontBin* font_bin)
 {
-   return "Hello World!";
+   this->font_bin = font_bin;
+}
+
+
+void UnicodeFontViewer::render()
+{
+   if (!(al_is_system_installed()))
+      {
+         std::stringstream error_message;
+         error_message << "UnicodeFontViewer" << "::" << "render" << ": error: " << "guard \"al_is_system_installed()\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   if (!(al_is_font_addon_initialized()))
+      {
+         std::stringstream error_message;
+         error_message << "UnicodeFontViewer" << "::" << "render" << ": error: " << "guard \"al_is_font_addon_initialized()\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   if (!(al_is_ttf_addon_initialized()))
+      {
+         std::stringstream error_message;
+         error_message << "UnicodeFontViewer" << "::" << "render" << ": error: " << "guard \"al_is_ttf_addon_initialized()\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   if (!(font_bin))
+      {
+         std::stringstream error_message;
+         error_message << "UnicodeFontViewer" << "::" << "render" << ": error: " << "guard \"font_bin\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   int32_t unicode_range_end = unicode_range_start+0x00ff;
+   ALLEGRO_FONT *ui_font = obtain_ui_font();
+   ALLEGRO_FONT *ui_font_mini = obtain_ui_font_mini();
+   ALLEGRO_FONT *unicode_font = obtain_unicode_font();
+   ALLEGRO_COLOR white = AllegroFlare::Color::White;
+   ALLEGRO_COLOR black = AllegroFlare::Color::Black;
+   std::stringstream range_string;
+
+   range_string << "you are currently viewing the range " << unicode_range_start << "-" << unicode_range_end;
+
+   al_draw_text(ui_font, white, 20, 20, 0, "Press the RIGHT ARROW and LEFT ARROW keys to flip through the pages");
+   al_draw_text(ui_font, white, 20, 60, 0, range_string.str().c_str());
+
+   //int y=90;
+   int line = 0;
+   int num_rows = 30;
+   int line_height = 80;
+   int row_width = 45;
+   int row = 0;
+   for (int32_t character=unicode_range_start; character<=unicode_range_end; character++)
+   {
+      int x = 100 + row*row_width;
+      int y = 100 + line*line_height;
+      draw_unicode_character(unicode_font, white, character, ALLEGRO_ALIGN_CENTER, x, y);
+      std::stringstream character_number_as_str;
+      character_number_as_str << character;
+      al_draw_text(ui_font_mini, white, x, y, 0, character_number_as_str.str().c_str());
+      row += 1;
+      if (row > num_rows) { row = 0; line++; }
+   }
+}
+
+void UnicodeFontViewer::previous_page()
+{
+   unicode_range_start -= 0x0100;
+   return;
+}
+
+void UnicodeFontViewer::next_page()
+{
+   unicode_range_start += 0x0100;
+   return;
+}
+
+void UnicodeFontViewer::draw_unicode_character(ALLEGRO_FONT* font, ALLEGRO_COLOR color, int32_t icon, int flags, float x, float y)
+{
+   static ALLEGRO_USTR *ustr = NULL;
+   if (!ustr) ustr = al_ustr_new("");
+   al_ustr_set_chr(ustr, 0, icon);
+   al_draw_ustr(font, color, x, y, flags, ustr);
+   return;
+}
+
+ALLEGRO_FONT* UnicodeFontViewer::obtain_unicode_font()
+{
+   if (!(font_bin))
+      {
+         std::stringstream error_message;
+         error_message << "UnicodeFontViewer" << "::" << "obtain_unicode_font" << ": error: " << "guard \"font_bin\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   return font_bin->auto_get("fa-solid-900.ttf 40");
+}
+
+ALLEGRO_FONT* UnicodeFontViewer::obtain_ui_font()
+{
+   if (!(font_bin))
+      {
+         std::stringstream error_message;
+         error_message << "UnicodeFontViewer" << "::" << "obtain_ui_font" << ": error: " << "guard \"font_bin\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   return font_bin->auto_get("Inter-Medium.ttf 20");
+}
+
+ALLEGRO_FONT* UnicodeFontViewer::obtain_ui_font_mini()
+{
+   if (!(font_bin))
+      {
+         std::stringstream error_message;
+         error_message << "UnicodeFontViewer" << "::" << "obtain_ui_font_mini" << ": error: " << "guard \"font_bin\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   return font_bin->auto_get("Inter-Medium.ttf 9");
 }
 } // namespace AllegroFlare
 

--- a/src/AllegroFlare/UnicodeFontViewer.cpp
+++ b/src/AllegroFlare/UnicodeFontViewer.cpp
@@ -1,0 +1,27 @@
+
+
+#include <AllegroFlare/UnicodeFontViewer.hpp>
+
+
+
+namespace AllegroFlare
+{
+
+
+UnicodeFontViewer::UnicodeFontViewer()
+{
+}
+
+
+UnicodeFontViewer::~UnicodeFontViewer()
+{
+}
+
+
+std::string UnicodeFontViewer::run()
+{
+   return "Hello World!";
+}
+} // namespace AllegroFlare
+
+

--- a/tests/AllegroFlare/UnicodeFontViewerTest.cpp
+++ b/tests/AllegroFlare/UnicodeFontViewerTest.cpp
@@ -1,9 +1,9 @@
 
 #include <gtest/gtest.h>
 
-#define ASSERT_THROW_WITH_MESSAGE(code, raised_exception_type, expected_exception_message) \
+#define EXPECT_THROW_WITH_MESSAGE(code, raised_exception_type, expected_exception_message) \
    try { code; FAIL() << "Expected " # raised_exception_type; } \
-   catch ( raised_exception_type const &err ) { ASSERT_EQ(std::string(expected_exception_message), err.what()); } \
+   catch ( raised_exception_type const &err ) { EXPECT_EQ(std::string(expected_exception_message), err.what()); } \
    catch (...) { FAIL() << "Expected " # raised_exception_type; }
 
 #include <AllegroFlare/Testing/WithAllegroRenderingFixture.hpp>
@@ -31,14 +31,62 @@ TEST_F(AllegroFlare_UnicodeFontViewerTest, render__without_allegro_initialized__
    AllegroFlare::UnicodeFontViewer unicode_font_viewer;
    std::string expected_error_message =
       "UnicodeFontViewer::render: error: guard \"al_is_system_installed()\" not met";
-   ASSERT_THROW_WITH_MESSAGE(unicode_font_viewer.render(), std::runtime_error, expected_error_message);
+   EXPECT_THROW_WITH_MESSAGE(unicode_font_viewer.render(), std::runtime_error, expected_error_message);
+}
+
+
+TEST_F(AllegroFlare_UnicodeFontViewerTest, render__without_font_addon_initialized__raises_an_error)
+{
+   al_init();
+   AllegroFlare::UnicodeFontViewer unicode_font_viewer;
+   std::string expected_error_message =
+      "UnicodeFontViewer::render: error: guard \"al_is_font_addon_initialized()\" not met";
+   EXPECT_THROW_WITH_MESSAGE(unicode_font_viewer.render(), std::runtime_error, expected_error_message);
+   al_uninstall_system();
+}
+
+
+TEST_F(AllegroFlare_UnicodeFontViewerTest, render__without_ttf_addon_initialized__raises_an_error)
+{
+   al_init();
+   al_init_font_addon();
+   AllegroFlare::UnicodeFontViewer unicode_font_viewer;
+   std::string expected_error_message =
+      "UnicodeFontViewer::render: error: guard \"al_is_ttf_addon_initialized()\" not met";
+   EXPECT_THROW_WITH_MESSAGE(unicode_font_viewer.render(), std::runtime_error, expected_error_message);
+   al_shutdown_font_addon();
+   al_uninstall_system();
+}
+
+
+TEST_F(AllegroFlare_UnicodeFontViewerTest, render__without_a_font_bin__raises_an_error)
+{
+   al_init();
+   al_init_font_addon();
+   al_init_ttf_addon();
+   AllegroFlare::UnicodeFontViewer unicode_font_viewer;
+   std::string expected_error_message =
+      "UnicodeFontViewer::render: error: guard \"font_bin\" not met";
+   EXPECT_THROW_WITH_MESSAGE(unicode_font_viewer.render(), std::runtime_error, expected_error_message);
+   al_shutdown_ttf_addon();
+   al_shutdown_font_addon();
+   al_uninstall_system();
 }
 
 
 TEST_F(AllegroFlare_UnicodeFontViewerTestWithAllegroRenderingFixture, render__will_not_blow_up)
 {
-   AllegroFlare::UnicodeFontViewer unicode_font_viewer;
+   AllegroFlare::FontBin &font_bin = get_font_bin_ref();
+   AllegroFlare::UnicodeFontViewer unicode_font_viewer(&font_bin, "Bravura.otf", 0x1D100);
+
+   al_clear_to_color({0});
+
    unicode_font_viewer.render();
+
+   al_flip_display();
+   sleep(1);
+
    SUCCEED();
 }
+
 

--- a/tests/AllegroFlare/UnicodeFontViewerTest.cpp
+++ b/tests/AllegroFlare/UnicodeFontViewerTest.cpp
@@ -9,6 +9,10 @@
 #include <AllegroFlare/Testing/WithAllegroRenderingFixture.hpp>
 
 
+#include <AllegroFlare/UnicodeFontViewer.hpp>
+#include <allegro5/allegro_primitives.h>
+
+
 class AllegroFlare_UnicodeFontViewerTest : public ::testing::Test
 {};
 
@@ -59,15 +63,32 @@ TEST_F(AllegroFlare_UnicodeFontViewerTest, render__without_ttf_addon_initialized
 }
 
 
-TEST_F(AllegroFlare_UnicodeFontViewerTest, render__without_a_font_bin__raises_an_error)
+TEST_F(AllegroFlare_UnicodeFontViewerTest, render__without_primitives_addon_initialized__raises_an_error)
 {
    al_init();
    al_init_font_addon();
    al_init_ttf_addon();
    AllegroFlare::UnicodeFontViewer unicode_font_viewer;
    std::string expected_error_message =
+      "UnicodeFontViewer::render: error: guard \"al_is_primitives_addon_initialized()\" not met";
+   EXPECT_THROW_WITH_MESSAGE(unicode_font_viewer.render(), std::runtime_error, expected_error_message);
+   al_shutdown_ttf_addon();
+   al_shutdown_font_addon();
+   al_uninstall_system();
+}
+
+
+TEST_F(AllegroFlare_UnicodeFontViewerTest, render__without_a_font_bin__raises_an_error)
+{
+   al_init();
+   al_init_font_addon();
+   al_init_ttf_addon();
+   al_init_primitives_addon();
+   AllegroFlare::UnicodeFontViewer unicode_font_viewer;
+   std::string expected_error_message =
       "UnicodeFontViewer::render: error: guard \"font_bin\" not met";
    EXPECT_THROW_WITH_MESSAGE(unicode_font_viewer.render(), std::runtime_error, expected_error_message);
+   al_shutdown_primitives_addon();
    al_shutdown_ttf_addon();
    al_shutdown_font_addon();
    al_uninstall_system();
@@ -84,7 +105,7 @@ TEST_F(AllegroFlare_UnicodeFontViewerTestWithAllegroRenderingFixture, render__wi
    unicode_font_viewer.render();
 
    al_flip_display();
-   sleep(1);
+   sleep(3);
 
    SUCCEED();
 }

--- a/tests/AllegroFlare/UnicodeFontViewerTest.cpp
+++ b/tests/AllegroFlare/UnicodeFontViewerTest.cpp
@@ -1,19 +1,44 @@
 
 #include <gtest/gtest.h>
 
+#define ASSERT_THROW_WITH_MESSAGE(code, raised_exception_type, expected_exception_message) \
+   try { code; FAIL() << "Expected " # raised_exception_type; } \
+   catch ( raised_exception_type const &err ) { ASSERT_EQ(std::string(expected_exception_message), err.what()); } \
+   catch (...) { FAIL() << "Expected " # raised_exception_type; }
+
+#include <AllegroFlare/Testing/WithAllegroRenderingFixture.hpp>
+
+
+class AllegroFlare_UnicodeFontViewerTest : public ::testing::Test
+{};
+
+class AllegroFlare_UnicodeFontViewerTestWithAllegroRenderingFixture
+   : public AllegroFlare::Testing::WithAllegroRenderingFixture
+{};
+
+
 #include <AllegroFlare/UnicodeFontViewer.hpp>
 
 
-TEST(AllegroFlare_UnicodeFontViewerTest, can_be_created_without_blowing_up)
+TEST_F(AllegroFlare_UnicodeFontViewerTest, can_be_created_without_blowing_up)
 {
    AllegroFlare::UnicodeFontViewer unicode_font_viewer;
 }
 
 
-TEST(AllegroFlare_UnicodeFontViewerTest, run__returns_the_expected_response)
+TEST_F(AllegroFlare_UnicodeFontViewerTest, render__without_allegro_initialized__raises_an_error)
 {
    AllegroFlare::UnicodeFontViewer unicode_font_viewer;
-   std::string expected_string = "Hello World!";
-   EXPECT_EQ(expected_string, unicode_font_viewer.run());
+   std::string expected_error_message =
+      "UnicodeFontViewer::render: error: guard \"al_is_system_installed()\" not met";
+   ASSERT_THROW_WITH_MESSAGE(unicode_font_viewer.render(), std::runtime_error, expected_error_message);
+}
+
+
+TEST_F(AllegroFlare_UnicodeFontViewerTestWithAllegroRenderingFixture, render__will_not_blow_up)
+{
+   AllegroFlare::UnicodeFontViewer unicode_font_viewer;
+   unicode_font_viewer.render();
+   SUCCEED();
 }
 

--- a/tests/AllegroFlare/UnicodeFontViewerTest.cpp
+++ b/tests/AllegroFlare/UnicodeFontViewerTest.cpp
@@ -1,0 +1,19 @@
+
+#include <gtest/gtest.h>
+
+#include <AllegroFlare/UnicodeFontViewer.hpp>
+
+
+TEST(AllegroFlare_UnicodeFontViewerTest, can_be_created_without_blowing_up)
+{
+   AllegroFlare::UnicodeFontViewer unicode_font_viewer;
+}
+
+
+TEST(AllegroFlare_UnicodeFontViewerTest, run__returns_the_expected_response)
+{
+   AllegroFlare::UnicodeFontViewer unicode_font_viewer;
+   std::string expected_string = "Hello World!";
+   EXPECT_EQ(expected_string, unicode_font_viewer.run());
+}
+


### PR DESCRIPTION
## Problem

Several examples (`FontAwesomeExample`, `FontBravuraExample`) need to display unicode characters and there is a class in those examples that should be extracted.

## Solution

Extract the `UnicodeFontViewer` from the example programs and replace the example program usage with the new viewer.

## Notes

Here's the `UnicodeFontViewer` in action:

![unicode-viewer](https://user-images.githubusercontent.com/772949/180489112-b7254b63-68d2-45e8-b0f6-860b65b7f95b.png)

A few tweaks were added to the initial class that was extracted, but a few more would be worth adding eventually:
- The class should probably be moved into `Elements` (or the new conceptual `Rudiments`)
- Should use [`al_get_font_ranges`](https://liballeg.org/a5docs/trunk/font.html#al_get_font_ranges) to get information so that user will know where reasonable ranges are in the font. That way they aren't paging through the ~16 million possible pages (with `uint32_t` having 4,294,967,295 possible character glyphs and 256 glyphs per page).
- Might add some page numbers or pagination numbering feature (`goto_page(num)`, for example)
- Might add a larger "detail view" with a larger rendering of the glyph, along with the bounding box data and line-height, ascent, etc data drawn as red and/or blue lines.
- Should add "centered" or "fill" rendering options for glyphs, for example...

Here's an example where the Bravura font characters draw on top of the numbers:
![AllegroFlare_UnicodeFontViewerTestWithAllegroRende](https://user-images.githubusercontent.com/772949/180491636-ba33f132-9ad8-44b5-942f-f6ebafc77957.png)

...this particular typeface uses glyph in a way that is different from typical word typography (it's anchor points are used to position glyphs on a music staff).

In situations like this, the user might prefer to view the glyphs such that they can see the full glyph.  Adding a toggleable option to view the glyphs positioned differently in the grid might be nice.  One of the toggleable options might have the glyph completely centered - could use [`al_get_ustr_dimensions()`](https://liballeg.org/a5docs/trunk/font.html#al_get_ustr_dimensions) and get the data needed to render the glyph centered in its grid cell.

