### PR TITLE
Escape sloppy prototype implementation

### DIFF
--- a/documentation/dependents.json
+++ b/documentation/dependents.json
@@ -513,6 +513,7 @@
     "AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D",
     "AllegroFlare/Prototypes/FixedRoom2D/InteractionEventData",
     "AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/CollectItem",
+    "AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/EnterRoom",
     "AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/SpawnDialog",
     "AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner"
   ],
@@ -528,7 +529,8 @@
   ],
   "std/vector<AllegroFlare/Prototypes/FixedRoom2D/Entities/Base>": [
     "AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper",
-    "AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper"
+    "AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper",
+    "AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D"
   ],
   "std/map<int, AllegroFlare/Prototypes/FixedRoom2D/Entities/Base>": [
     "AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper"
@@ -536,6 +538,11 @@
   "std/map<std/string, AllegroFlare/Prototypes/FixedRoom2D/Entities/Base>": [
     "AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper",
     "AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D",
+    "AllegroFlare/Prototypes/FixedRoom2D/Room",
+    "AllegroFlare/Prototypes/FixedRoom2D/RoomFactory"
+  ],
+  "std/map<std/string, std/string>": [
+    "AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper",
     "AllegroFlare/Prototypes/FixedRoom2D/Room",
     "AllegroFlare/Prototypes/FixedRoom2D/RoomFactory"
   ],
@@ -595,6 +602,10 @@
     "AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner"
   ],
   "AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/CollectItem": [
+    "AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D",
+    "AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner"
+  ],
+  "AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/EnterRoom": [
     "AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D",
     "AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner"
   ],

--- a/documentation/dependents.json
+++ b/documentation/dependents.json
@@ -530,7 +530,8 @@
   "std/vector<AllegroFlare/Prototypes/FixedRoom2D/Entities/Base>": [
     "AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper",
     "AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper",
-    "AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D"
+    "AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D",
+    "AllegroFlare/Prototypes/FixedRoom2D/Room"
   ],
   "std/map<int, AllegroFlare/Prototypes/FixedRoom2D/Entities/Base>": [
     "AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper"
@@ -571,7 +572,8 @@
   ],
   "AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper": [
     "AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D",
-    "AllegroFlare/Prototypes/FixedRoom2D/Room"
+    "AllegroFlare/Prototypes/FixedRoom2D/Room",
+    "AllegroFlare/Prototypes/FixedRoom2D/RoomFactory"
   ],
   "std/map<std/string, AllegroFlare/Prototypes/FixedRoom2D/Script>": [
     "AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D",

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -3141,10 +3141,13 @@ table td
   <td class="method">find_entity_by_dictionary_name(1)</td>
 </tr>
 <tr>
+  <td class="method">order_by_id(1)</td>
+</tr>
+<tr>
   <td class="method">select_all_ordered_by_id(1)</td>
 </tr>
 <tr>
-  <td class="method">get_entities_from_entity_names(1)</td>
+  <td class="method">get_entities_by_entity_names(1)</td>
 </tr>
 <tr>
   <td class="method">select_all_entity_names_in_room_name(1)</td>

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -107,6 +107,7 @@ table td
   <li><a href="#quintessence/AllegroFlare/Prototypes/FixedRoom2D/Screen.q.yml">quintessence/AllegroFlare/Prototypes/FixedRoom2D/Screen.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/Prototypes/FixedRoom2D/Script.q.yml">quintessence/AllegroFlare/Prototypes/FixedRoom2D/Script.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/CollectItem.q.yml">quintessence/AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/CollectItem.q.yml</a></li>
+  <li><a href="#quintessence/AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/EnterRoom.q.yml">quintessence/AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/EnterRoom.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/SpawnDialog.q.yml">quintessence/AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/SpawnDialog.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner.q.yml">quintessence/AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/Screens/GameOverScreen.q.yml">quintessence/AllegroFlare/Screens/GameOverScreen.q.yml</a></li>
@@ -3155,6 +3156,9 @@ table td
 <tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;std::map&lt;std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*&gt;*&quot;, &quot;headers&quot;=&gt;[&quot;string&quot;, &quot;AllegroFlare/Prototypes/FixedRoom2D/Entities/Base.hpp&quot;]}</td>
 </tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;std::map&lt;std::string, std::string&gt;*&quot;, &quot;headers&quot;=&gt;[&quot;map&quot;, &quot;string&quot;]}</td>
+</tr>
     </table>
   </div>
 </ul>
@@ -3293,6 +3297,15 @@ table td
   <td class="private_method">process_script_event(1)</td>
 </tr>
 <tr>
+  <td class="method">render_entities_in_current_room()</td>
+</tr>
+<tr>
+  <td class="method">get_entities_in_current_room()</td>
+</tr>
+<tr>
+  <td class="method">get_dictionary_name_of_current_room()</td>
+</tr>
+<tr>
   <td class="method">update_all_rooms()</td>
 </tr>
 <tr>
@@ -3409,6 +3422,9 @@ table td
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::CollectItem&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/CollectItem.hpp&quot;]}</td>
 </tr>
 <tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::EnterRoom&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/EnterRoom.hpp&quot;]}</td>
+</tr>
+<tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::GameEvent*&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/GameEvent.hpp&quot;]}</td>
 </tr>
 <tr>
@@ -3416,6 +3432,9 @@ table td
 </tr>
 <tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::Prototypes::FixedRoom2D::RoomFactory&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/Prototypes/FixedRoom2D/RoomFactory.hpp&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;std::vector&lt;AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*&gt;&quot;, &quot;headers&quot;=&gt;[&quot;vector&quot;, &quot;AllegroFlare/Prototypes/FixedRoom2D/Entities/Base.hpp&quot;]}</td>
 </tr>
     </table>
   </div>
@@ -3488,6 +3507,9 @@ table td
   <td class="method">set_entity_dictionary(1)</td>
 </tr>
 <tr>
+  <td class="method">set_entity_room_associations(1)</td>
+</tr>
+<tr>
   <td class="method">suspend()</td>
 </tr>
 <tr>
@@ -3506,7 +3528,7 @@ table td
   <td class="method">update()</td>
 </tr>
 <tr>
-  <td class="method">render()</td>
+  <td class="method">render(1)</td>
 </tr>
 <tr>
   <td class="method">interact_with_item_under_cursor()</td>
@@ -3555,6 +3577,9 @@ table td
 <tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::Prototypes::FixedRoom2D::EventNames::INTERACTION_EVENT_NAME&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/Prototypes/FixedRoom2D/EventNames.hpp&quot;]}</td>
 </tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;std::map&lt;std::string, std::string&gt;*&quot;, &quot;headers&quot;=&gt;[&quot;map&quot;, &quot;string&quot;]}</td>
+</tr>
     </table>
   </div>
 </ul>
@@ -3592,6 +3617,10 @@ table td
   <td class="property">entity_dictionary</td>
   <td class="property">std::map&lt;std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*&gt;*</td>
 </tr>
+<tr>
+  <td class="property">entity_room_associations</td>
+  <td class="property">std::map&lt;std::string, std::string&gt;*</td>
+</tr>
     </table>
      <table>
 <tr>
@@ -3613,6 +3642,9 @@ table td
 </tr>
 <tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;std::map&lt;std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*&gt;*&quot;, &quot;headers&quot;=&gt;[&quot;map&quot;, &quot;string&quot;, &quot;AllegroFlare/Prototypes/FixedRoom2D/Entities/Base.hpp&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;std::map&lt;std::string, std::string&gt;*&quot;, &quot;headers&quot;=&gt;[&quot;map&quot;, &quot;string&quot;]}</td>
 </tr>
     </table>
   </div>
@@ -3796,6 +3828,24 @@ table td
 </ul>
 <ul>
   <div class="component">
+    <h3 id="quintessence/AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/EnterRoom.q.yml">quintessence/AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/EnterRoom.q.yml</h3>
+     <table>
+<tr>
+  <td class="property">room_dictionary_name_to_enter</td>
+  <td class="property">std::string</td>
+</tr>
+    </table>
+     <table>
+    </table>
+     <table>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::GameEventDatas::Base&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/GameEventDatas/Base.hpp&quot;]}</td>
+</tr>
+    </table>
+  </div>
+</ul>
+<ul>
+  <div class="component">
     <h3 id="quintessence/AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/SpawnDialog.q.yml">quintessence/AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/SpawnDialog.q.yml</h3>
      <table>
 <tr>
@@ -3920,6 +3970,9 @@ table td
 </tr>
 <tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::CollectItem&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/CollectItem.hpp&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::EnterRoom&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/EnterRoom.hpp&quot;]}</td>
 </tr>
     </table>
   </div>
@@ -5483,6 +5536,7 @@ table td
     "AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D",
     "AllegroFlare/Prototypes/FixedRoom2D/InteractionEventData",
     "AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/CollectItem",
+    "AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/EnterRoom",
     "AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/SpawnDialog",
     "AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner"
   ],
@@ -5498,7 +5552,8 @@ table td
   ],
   "std/vector<AllegroFlare/Prototypes/FixedRoom2D/Entities/Base>": [
     "AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper",
-    "AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper"
+    "AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper",
+    "AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D"
   ],
   "std/map<int, AllegroFlare/Prototypes/FixedRoom2D/Entities/Base>": [
     "AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper"
@@ -5506,6 +5561,11 @@ table td
   "std/map<std/string, AllegroFlare/Prototypes/FixedRoom2D/Entities/Base>": [
     "AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper",
     "AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D",
+    "AllegroFlare/Prototypes/FixedRoom2D/Room",
+    "AllegroFlare/Prototypes/FixedRoom2D/RoomFactory"
+  ],
+  "std/map<std/string, std/string>": [
+    "AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper",
     "AllegroFlare/Prototypes/FixedRoom2D/Room",
     "AllegroFlare/Prototypes/FixedRoom2D/RoomFactory"
   ],
@@ -5565,6 +5625,10 @@ table td
     "AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner"
   ],
   "AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/CollectItem": [
+    "AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D",
+    "AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner"
+  ],
+  "AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/EnterRoom": [
     "AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D",
     "AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner"
   ],

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -3122,6 +3122,10 @@ table td
   <td class="property">entity_dictionary</td>
   <td class="property">std::map&lt;std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*&gt;*</td>
 </tr>
+<tr>
+  <td class="property">entity_room_associations</td>
+  <td class="property">std::map&lt;std::string, std::string&gt;*</td>
+</tr>
     </table>
      <table>
 <tr>
@@ -3138,6 +3142,9 @@ table td
 </tr>
 <tr>
   <td class="method">select_all_ordered_by_id(1)</td>
+</tr>
+<tr>
+  <td class="method">select_all_entity_names_in_room_name(1)</td>
 </tr>
     </table>
      <table>

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -3138,10 +3138,13 @@ table td
   <td class="method">find_dictionary_name_of_entity_that_cursor_is_now_over()</td>
 </tr>
 <tr>
-  <td class="method">find_by_dictionary_listing_name(1)</td>
+  <td class="method">find_entity_by_dictionary_name(1)</td>
 </tr>
 <tr>
   <td class="method">select_all_ordered_by_id(1)</td>
+</tr>
+<tr>
+  <td class="method">get_entities_from_entity_names(1)</td>
 </tr>
 <tr>
   <td class="method">select_all_entity_names_in_room_name(1)</td>

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -3129,10 +3129,10 @@ table td
     </table>
      <table>
 <tr>
-  <td class="method">select_all_in_room(1)</td>
+  <td class="method">select_all_in_room_ordered_by_id(1)</td>
 </tr>
 <tr>
-  <td class="method">select_all_unordered()</td>
+  <td class="method">select_all()</td>
 </tr>
 <tr>
   <td class="method">find_dictionary_name_of_entity_that_cursor_is_now_over()</td>
@@ -3142,9 +3142,6 @@ table td
 </tr>
 <tr>
   <td class="method">order_by_id(1)</td>
-</tr>
-<tr>
-  <td class="method">select_all_ordered_by_id(1)</td>
 </tr>
 <tr>
   <td class="method">get_entities_by_entity_names(1)</td>
@@ -3296,6 +3293,15 @@ table td
 </tr>
 <tr>
   <td class="method">enter_room(1)</td>
+</tr>
+<tr>
+  <td class="method">unhover_any_and_all_entities()</td>
+</tr>
+<tr>
+  <td class="method">reset_cursors_to_default_in_all_rooms()</td>
+</tr>
+<tr>
+  <td class="method">get_current_room_dictionary_name(1)</td>
 </tr>
 <tr>
   <td class="method">render()</td>
@@ -3491,12 +3497,8 @@ table td
   <td class="property">AllegroFlare::EventEmitter*</td>
 </tr>
 <tr>
-  <td class="property">entity_dictionary</td>
-  <td class="property">std::map&lt;std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*&gt;*</td>
-</tr>
-<tr>
   <td class="property">entity_collection_helper</td>
-  <td class="property">AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper</td>
+  <td class="property">AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper*</td>
 </tr>
 <tr>
   <td class="property">cursor</td>
@@ -3516,12 +3518,6 @@ table td
 </tr>
     </table>
      <table>
-<tr>
-  <td class="method">set_entity_dictionary(1)</td>
-</tr>
-<tr>
-  <td class="method">set_entity_room_associations(1)</td>
-</tr>
 <tr>
   <td class="method">suspend()</td>
 </tr>
@@ -3547,7 +3543,10 @@ table td
   <td class="method">interact_with_item_under_cursor()</td>
 </tr>
 <tr>
-  <td class="method">move_cursor(2)</td>
+  <td class="method">move_cursor(3)</td>
+</tr>
+<tr>
+  <td class="method">reset_cursor_to_default()</td>
 </tr>
 <tr>
   <td class="private_method">emit_interaction_event(3)</td>
@@ -3576,7 +3575,7 @@ table td
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;std::map&lt;std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*&gt;*&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/Prototypes/FixedRoom2D/Entities/Base.hpp&quot;]}</td>
 </tr>
 <tr>
-  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.hpp&quot;]}</td>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper*&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.hpp&quot;]}</td>
 </tr>
 <tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;std::map&lt;std::string, AllegroFlare::Prototypes::FixedRoom2D::Script&gt;&quot;, &quot;headers&quot;=&gt;[&quot;map&quot;, &quot;AllegroFlare/Prototypes/FixedRoom2D/Script.hpp&quot;]}</td>
@@ -3592,6 +3591,9 @@ table td
 </tr>
 <tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;std::map&lt;std::string, std::string&gt;*&quot;, &quot;headers&quot;=&gt;[&quot;map&quot;, &quot;string&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;std::vector&lt;AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*&gt;&quot;, &quot;headers&quot;=&gt;[&quot;vector&quot;, &quot;AllegroFlare/Prototypes/FixedRoom2D/Entities/Base.hpp&quot;]}</td>
 </tr>
     </table>
   </div>
@@ -3627,12 +3629,8 @@ table td
   <td class="property">AllegroFlare::EventEmitter*</td>
 </tr>
 <tr>
-  <td class="property">entity_dictionary</td>
-  <td class="property">std::map&lt;std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*&gt;*</td>
-</tr>
-<tr>
-  <td class="property">entity_room_associations</td>
-  <td class="property">std::map&lt;std::string, std::string&gt;*</td>
+  <td class="property">entity_collection_helper</td>
+  <td class="property">AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper*</td>
 </tr>
     </table>
      <table>
@@ -3658,6 +3656,9 @@ table td
 </tr>
 <tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;std::map&lt;std::string, std::string&gt;*&quot;, &quot;headers&quot;=&gt;[&quot;map&quot;, &quot;string&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper*&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.hpp&quot;]}</td>
 </tr>
     </table>
   </div>
@@ -5566,7 +5567,8 @@ table td
   "std/vector<AllegroFlare/Prototypes/FixedRoom2D/Entities/Base>": [
     "AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper",
     "AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper",
-    "AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D"
+    "AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D",
+    "AllegroFlare/Prototypes/FixedRoom2D/Room"
   ],
   "std/map<int, AllegroFlare/Prototypes/FixedRoom2D/Entities/Base>": [
     "AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper"
@@ -5607,7 +5609,8 @@ table td
   ],
   "AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper": [
     "AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D",
-    "AllegroFlare/Prototypes/FixedRoom2D/Room"
+    "AllegroFlare/Prototypes/FixedRoom2D/Room",
+    "AllegroFlare/Prototypes/FixedRoom2D/RoomFactory"
   ],
   "std/map<std/string, AllegroFlare/Prototypes/FixedRoom2D/Script>": [
     "AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D",

--- a/include/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.hpp
+++ b/include/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.hpp
@@ -31,8 +31,9 @@ namespace AllegroFlare
             std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> select_all_unordered();
             std::string find_dictionary_name_of_entity_that_cursor_is_now_over();
             AllegroFlare::Prototypes::FixedRoom2D::Entities::Base* find_entity_by_dictionary_name(std::string dictionary_listing_name=nullptr);
+            std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> order_by_id(std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> entities_to_order={});
             std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> select_all_ordered_by_id(std::string room_name="[unset-room_name]");
-            void get_entities_from_entity_names(std::vector<std::string> entity_names={});
+            std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> get_entities_by_entity_names(std::vector<std::string> entity_dictionary_names={});
             std::vector<std::string> select_all_entity_names_in_room_name(std::string room_name="[unset-room_name]");
          };
       }

--- a/include/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.hpp
+++ b/include/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.hpp
@@ -27,12 +27,11 @@ namespace AllegroFlare
             void set_entity_room_associations(std::map<std::string, std::string>* entity_room_associations);
             std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>* get_entity_dictionary();
             std::map<std::string, std::string>* get_entity_room_associations();
-            std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> select_all_in_room(std::string room_name="[unset-room_name]");
-            std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> select_all_unordered();
+            std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> select_all_in_room_ordered_by_id(std::string room_name="[unset-room_name]");
+            std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> select_all();
             std::string find_dictionary_name_of_entity_that_cursor_is_now_over();
             AllegroFlare::Prototypes::FixedRoom2D::Entities::Base* find_entity_by_dictionary_name(std::string dictionary_listing_name=nullptr);
             std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> order_by_id(std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> entities_to_order={});
-            std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> select_all_ordered_by_id(std::string room_name="[unset-room_name]");
             std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> get_entities_by_entity_names(std::vector<std::string> entity_dictionary_names={});
             std::vector<std::string> select_all_entity_names_in_room_name(std::string room_name="[unset-room_name]");
          };

--- a/include/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.hpp
+++ b/include/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.hpp
@@ -2,6 +2,7 @@
 
 
 #include <AllegroFlare/Prototypes/FixedRoom2D/Entities/Base.hpp>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -16,18 +17,22 @@ namespace AllegroFlare
          {
          private:
             std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>* entity_dictionary;
+            std::map<std::string, std::string>* entity_room_associations;
 
          public:
-            EntityCollectionHelper(std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>* entity_dictionary=nullptr);
+            EntityCollectionHelper(std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>* entity_dictionary=nullptr, std::map<std::string, std::string>* entity_room_associations=nullptr);
             ~EntityCollectionHelper();
 
             void set_entity_dictionary(std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>* entity_dictionary);
+            void set_entity_room_associations(std::map<std::string, std::string>* entity_room_associations);
             std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>* get_entity_dictionary();
+            std::map<std::string, std::string>* get_entity_room_associations();
             std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> select_all_in_room(std::string room_name="[unset-room_name]");
             std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> select_all_unordered();
             std::string find_dictionary_name_of_entity_that_cursor_is_now_over();
             AllegroFlare::Prototypes::FixedRoom2D::Entities::Base* find_by_dictionary_listing_name(std::string dictionary_listing_name=nullptr);
             std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> select_all_ordered_by_id(std::string room_name="[unset-room_name]");
+            std::vector<std::string> select_all_entity_names_in_room_name(std::string room_name="[unset-room_name]");
          };
       }
    }

--- a/include/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.hpp
+++ b/include/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.hpp
@@ -30,8 +30,9 @@ namespace AllegroFlare
             std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> select_all_in_room(std::string room_name="[unset-room_name]");
             std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> select_all_unordered();
             std::string find_dictionary_name_of_entity_that_cursor_is_now_over();
-            AllegroFlare::Prototypes::FixedRoom2D::Entities::Base* find_by_dictionary_listing_name(std::string dictionary_listing_name=nullptr);
+            AllegroFlare::Prototypes::FixedRoom2D::Entities::Base* find_entity_by_dictionary_name(std::string dictionary_listing_name=nullptr);
             std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> select_all_ordered_by_id(std::string room_name="[unset-room_name]");
+            void get_entities_from_entity_names(std::vector<std::string> entity_names={});
             std::vector<std::string> select_all_entity_names_in_room_name(std::string room_name="[unset-room_name]");
          };
       }

--- a/include/AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D.hpp
+++ b/include/AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D.hpp
@@ -62,6 +62,9 @@ namespace AllegroFlare
             void load_story_and_start();
             void update();
             bool enter_room(std::string room_name="[unset-room_name]");
+            void unhover_any_and_all_entities();
+            void reset_cursors_to_default_in_all_rooms();
+            std::string get_current_room_dictionary_name(AllegroFlare::Prototypes::FixedRoom2D::Room* room=nullptr);
             void render();
             void process_subscribed_to_game_event(AllegroFlare::GameEvent* game_event=nullptr);
             void process_interaction_event(AllegroFlare::GameEventDatas::Base* game_event_data=nullptr);

--- a/include/AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D.hpp
+++ b/include/AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D.hpp
@@ -18,6 +18,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <vector>
 
 
 namespace AllegroFlare
@@ -65,6 +66,9 @@ namespace AllegroFlare
             void process_subscribed_to_game_event(AllegroFlare::GameEvent* game_event=nullptr);
             void process_interaction_event(AllegroFlare::GameEventDatas::Base* game_event_data=nullptr);
             void process_script_event(AllegroFlare::GameEventDatas::Base* game_event_data=nullptr);
+            void render_entities_in_current_room();
+            std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> get_entities_in_current_room();
+            std::string get_dictionary_name_of_current_room();
             void update_all_rooms();
             void suspend_all_rooms();
             void resume_all_rooms();

--- a/include/AllegroFlare/Prototypes/FixedRoom2D/Room.hpp
+++ b/include/AllegroFlare/Prototypes/FixedRoom2D/Room.hpp
@@ -6,6 +6,7 @@
 #include <AllegroFlare/Prototypes/FixedRoom2D/Cursor.hpp>
 #include <AllegroFlare/Prototypes/FixedRoom2D/Entities/Base.hpp>
 #include <AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.hpp>
+#include <map>
 #include <string>
 
 
@@ -35,13 +36,14 @@ namespace AllegroFlare
             void set_event_emitter(AllegroFlare::EventEmitter* event_emitter);
             bool get_suspended();
             void set_entity_dictionary(std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>* entity_dictionary=nullptr);
+            void set_entity_room_associations(std::map<std::string, std::string>* entity_room_associations=nullptr);
             void suspend();
             void resume();
             void show();
             void hide();
             void initialize();
             void update();
-            void render();
+            void render(std::string this_rooms_dictionary_name__this_injection_is_temporary_measure="[unset-this_rooms_dictionary_name__this_injection_is_temporary_measure]");
             void interact_with_item_under_cursor();
             void move_cursor(float distance_x=0.0, float distance_y=0.0);
             void emit_interaction_event(std::string item_dictionary_name="[unset-item_dictionary_name]", float cursor_x=0.0, float cursor_y=0.0);

--- a/include/AllegroFlare/Prototypes/FixedRoom2D/Room.hpp
+++ b/include/AllegroFlare/Prototypes/FixedRoom2D/Room.hpp
@@ -6,8 +6,8 @@
 #include <AllegroFlare/Prototypes/FixedRoom2D/Cursor.hpp>
 #include <AllegroFlare/Prototypes/FixedRoom2D/Entities/Base.hpp>
 #include <AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.hpp>
-#include <map>
 #include <string>
+#include <vector>
 
 
 namespace AllegroFlare
@@ -21,22 +21,20 @@ namespace AllegroFlare
          private:
             AllegroFlare::FontBin* font_bin;
             AllegroFlare::EventEmitter* event_emitter;
-            std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>* entity_dictionary;
-            AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper entity_collection_helper;
+            AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper* entity_collection_helper;
             AllegroFlare::Prototypes::FixedRoom2D::Cursor cursor;
             bool suspended;
             float suspended_at;
             bool initialized;
 
          public:
-            Room(AllegroFlare::FontBin* font_bin=nullptr, AllegroFlare::EventEmitter* event_emitter=nullptr, std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>* entity_dictionary=nullptr);
+            Room(AllegroFlare::FontBin* font_bin=nullptr, AllegroFlare::EventEmitter* event_emitter=nullptr, AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper* entity_collection_helper=nullptr);
             ~Room();
 
             void set_font_bin(AllegroFlare::FontBin* font_bin);
             void set_event_emitter(AllegroFlare::EventEmitter* event_emitter);
+            void set_entity_collection_helper(AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper* entity_collection_helper);
             bool get_suspended();
-            void set_entity_dictionary(std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>* entity_dictionary=nullptr);
-            void set_entity_room_associations(std::map<std::string, std::string>* entity_room_associations=nullptr);
             void suspend();
             void resume();
             void show();
@@ -45,7 +43,8 @@ namespace AllegroFlare
             void update();
             void render(std::string this_rooms_dictionary_name__this_injection_is_temporary_measure="[unset-this_rooms_dictionary_name__this_injection_is_temporary_measure]");
             void interact_with_item_under_cursor();
-            void move_cursor(float distance_x=0.0, float distance_y=0.0);
+            void move_cursor(float distance_x=0.0, float distance_y=0.0, std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> entities_in_this_room={});
+            void reset_cursor_to_default();
             void emit_interaction_event(std::string item_dictionary_name="[unset-item_dictionary_name]", float cursor_x=0.0, float cursor_y=0.0);
          };
       }

--- a/include/AllegroFlare/Prototypes/FixedRoom2D/RoomFactory.hpp
+++ b/include/AllegroFlare/Prototypes/FixedRoom2D/RoomFactory.hpp
@@ -4,10 +4,8 @@
 #include <AllegroFlare/BitmapBin.hpp>
 #include <AllegroFlare/EventEmitter.hpp>
 #include <AllegroFlare/FontBin.hpp>
-#include <AllegroFlare/Prototypes/FixedRoom2D/Entities/Base.hpp>
+#include <AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.hpp>
 #include <AllegroFlare/Prototypes/FixedRoom2D/Room.hpp>
-#include <map>
-#include <string>
 
 
 namespace AllegroFlare
@@ -22,11 +20,10 @@ namespace AllegroFlare
             AllegroFlare::BitmapBin* bitmap_bin;
             AllegroFlare::FontBin* font_bin;
             AllegroFlare::EventEmitter* event_emitter;
-            std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>* entity_dictionary;
-            std::map<std::string, std::string>* entity_room_associations;
+            AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper* entity_collection_helper;
 
          public:
-            RoomFactory(AllegroFlare::BitmapBin* bitmap_bin=nullptr, AllegroFlare::FontBin* font_bin=nullptr, AllegroFlare::EventEmitter* event_emitter=nullptr, std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>* entity_dictionary=nullptr, std::map<std::string, std::string>* entity_room_associations=nullptr);
+            RoomFactory(AllegroFlare::BitmapBin* bitmap_bin=nullptr, AllegroFlare::FontBin* font_bin=nullptr, AllegroFlare::EventEmitter* event_emitter=nullptr, AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper* entity_collection_helper=nullptr);
             ~RoomFactory();
 
             AllegroFlare::Prototypes::FixedRoom2D::Room* create_room(float width=(1920-200), float height=(1080-200));

--- a/include/AllegroFlare/Prototypes/FixedRoom2D/RoomFactory.hpp
+++ b/include/AllegroFlare/Prototypes/FixedRoom2D/RoomFactory.hpp
@@ -23,9 +23,10 @@ namespace AllegroFlare
             AllegroFlare::FontBin* font_bin;
             AllegroFlare::EventEmitter* event_emitter;
             std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>* entity_dictionary;
+            std::map<std::string, std::string>* entity_room_associations;
 
          public:
-            RoomFactory(AllegroFlare::BitmapBin* bitmap_bin=nullptr, AllegroFlare::FontBin* font_bin=nullptr, AllegroFlare::EventEmitter* event_emitter=nullptr, std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>* entity_dictionary=nullptr);
+            RoomFactory(AllegroFlare::BitmapBin* bitmap_bin=nullptr, AllegroFlare::FontBin* font_bin=nullptr, AllegroFlare::EventEmitter* event_emitter=nullptr, std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>* entity_dictionary=nullptr, std::map<std::string, std::string>* entity_room_associations=nullptr);
             ~RoomFactory();
 
             AllegroFlare::Prototypes::FixedRoom2D::Room* create_room(float width=(1920-200), float height=(1080-200));

--- a/include/AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/EnterRoom.hpp
+++ b/include/AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/EnterRoom.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+
+#include <AllegroFlare/GameEventDatas/Base.hpp>
+#include <string>
+
+
+namespace AllegroFlare
+{
+   namespace Prototypes
+   {
+      namespace FixedRoom2D
+      {
+         namespace ScriptEventDatas
+         {
+            class EnterRoom : public AllegroFlare::GameEventDatas::Base
+            {
+            private:
+               std::string room_dictionary_name_to_enter;
+
+            public:
+               EnterRoom(std::string room_dictionary_name_to_enter="[unset-room_dictionary_name_to_enter]");
+               ~EnterRoom();
+
+               void set_room_dictionary_name_to_enter(std::string room_dictionary_name_to_enter);
+               std::string get_room_dictionary_name_to_enter();
+            };
+         }
+      }
+   }
+}
+
+
+

--- a/quintessence/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.q.yml
+++ b/quintessence/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.q.yml
@@ -75,6 +75,31 @@ functions:
       return it->second;
 
 
+  - name: order_by_id
+    type: std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>
+    parameters:
+      - name: entities_to_order
+        type: std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>
+        default_argument: '{}'
+    body: |
+      std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> result;
+      std::map<int, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> as_ids;
+
+      for (auto &entity : entities_to_order)
+      {
+         if (!entity) continue;
+         as_ids[entity->get_id()] = entity;
+      }
+
+      for (auto &entity : as_ids)
+      {
+         result.push_back(entity.second);
+      }
+      return result;
+    body_dependency_symbols:
+      - std::map<int, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>
+
+
   - name: select_all_ordered_by_id
     type: std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>
     parameters:
@@ -100,17 +125,32 @@ functions:
       - std::map<int, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>
 
 
-  - name: get_entities_from_entity_names
+  - name: get_entities_by_entity_names
     parameters:
-      - name: entity_names
+      - name: entity_dictionary_names
         type: std::vector<std::string>
         default_argument: '{}'
     guards: [ entity_dictionary ]
+    type: std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>
     body: |
+      std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> result;
+      for (auto &entity_dictionary_name : entity_dictionary_names)
       {
-         
+         AllegroFlare::Prototypes::FixedRoom2D::Entities::Base* found_entity =
+            find_entity_by_dictionary_name(entity_dictionary_name);
+
+         if (!found_entity)
+         {
+            std::cout << "[FixedRoom2D::EntityCollectionHelper::get_entities_from_entity_names]: warning: The provided "
+                      << "entity name \"" << entity_dictionary_name << "\" does not have a listing. Ignoring."
+                      << std::endl;
+         }
+         else
+         {
+            result.push_back(found_entity);
+         }
       }
-      return;
+      return result;
 
 
   - name: select_all_entity_names_in_room_name

--- a/quintessence/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.q.yml
+++ b/quintessence/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.q.yml
@@ -106,5 +106,7 @@ dependencies:
     headers: [ map, AllegroFlare/Prototypes/FixedRoom2D/Entities/Base.hpp ]
   - symbol: std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>*
     headers: [ string, AllegroFlare/Prototypes/FixedRoom2D/Entities/Base.hpp ]
+  - symbol: std::map<std::string, std::string>*
+    headers: [ map, string ]
 
 

--- a/quintessence/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.q.yml
+++ b/quintessence/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.q.yml
@@ -8,6 +8,13 @@ properties:
     getter: true
     setter: true
 
+  - name: entity_room_associations
+    type: std::map<std::string, std::string>*
+    init_with: nullptr
+    constructor_arg: true
+    getter: true
+    setter: true
+
 
 functions:
 
@@ -91,6 +98,22 @@ functions:
       return result;
     body_dependency_symbols:
       - std::map<int, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>
+
+
+  - name: select_all_entity_names_in_room_name
+    parameters:
+      - name: room_name
+        type: std::string
+        default_argument: '"[unset-room_name]"'
+    guards: [ entity_room_associations ]
+    type: std::vector<std::string>
+    body: |
+      std::vector<std::string> result;
+      for (auto &entity_room_association : (*entity_room_associations))
+      {
+         if (entity_room_association.second == room_name) result.push_back(entity_room_association.first);
+      }
+      return result;
 
 
 dependencies:

--- a/quintessence/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.q.yml
+++ b/quintessence/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.q.yml
@@ -60,7 +60,7 @@ functions:
       return "";
 
 
-  - name: find_by_dictionary_listing_name
+  - name: find_entity_by_dictionary_name
     type: AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*
     parameters:
       - name: dictionary_listing_name
@@ -98,6 +98,19 @@ functions:
       return result;
     body_dependency_symbols:
       - std::map<int, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>
+
+
+  - name: get_entities_from_entity_names
+    parameters:
+      - name: entity_names
+        type: std::vector<std::string>
+        default_argument: '{}'
+    guards: [ entity_dictionary ]
+    body: |
+      {
+         
+      }
+      return;
 
 
   - name: select_all_entity_names_in_room_name

--- a/quintessence/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.q.yml
+++ b/quintessence/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.q.yml
@@ -19,7 +19,7 @@ properties:
 functions:
 
 
-  - name: select_all_in_room
+  - name: select_all_in_room_ordered_by_id
     type: std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>
     parameters:
       - name: room_name
@@ -27,23 +27,18 @@ functions:
         default_argument: '"[unset-room_name]"'
     guards: [ entity_dictionary ]
     body: |
-      std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> result;
-      for (auto &entity : *entity_dictionary)
-      {
-         // if entity has the attribute, include it in the result
-      }
-      return result;
+      std::vector<std::string> entity_names_in_room = select_all_entity_names_in_room_name(room_name);
+      std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> entities =
+         get_entities_by_entity_names(entity_names_in_room);
+      return order_by_id(entities);
 
 
-  - name: select_all_unordered
+  - name: select_all
     type: std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>
     guards: [ entity_dictionary ]
     body: |
       std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> result;
-      for (auto &entity : *entity_dictionary)
-      {
-         result.push_back(entity.second);
-      }
+      for (auto &entity : *entity_dictionary) { result.push_back(entity.second); }
       return result;
     body_dependency_symbols:
       - std::map<int, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>
@@ -89,31 +84,6 @@ functions:
       {
          if (!entity) continue;
          as_ids[entity->get_id()] = entity;
-      }
-
-      for (auto &entity : as_ids)
-      {
-         result.push_back(entity.second);
-      }
-      return result;
-    body_dependency_symbols:
-      - std::map<int, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>
-
-
-  - name: select_all_ordered_by_id
-    type: std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>
-    parameters:
-      - name: room_name
-        type: std::string
-        default_argument: '"[unset-room_name]"'
-    guards: [ entity_dictionary ]
-    body: |
-      std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> result;
-      std::map<int, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> as_ids;
-
-      for (auto &entity : *entity_dictionary)
-      {
-         as_ids[entity.second->get_id()] = entity.second;
       }
 
       for (auto &entity : as_ids)

--- a/quintessence/AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D.q.yml
+++ b/quintessence/AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D.q.yml
@@ -127,11 +127,6 @@ functions:
   - name: initialize
     guards: [ (!initialized), bitmap_bin, event_emitter, audio_controller ]
     body: |
-      AllegroFlare::Prototypes::FixedRoom2D::EntityFactory entity_factory(bitmap_bin);
-      AllegroFlare::Prototypes::FixedRoom2D::RoomFactory room_factory(
-         bitmap_bin, font_bin, event_emitter, &entity_dictionary
-      );
-
       subscribed_to_game_event_names = {
          AllegroFlare::Prototypes::FixedRoom2D::EventNames::INTERACTION_EVENT_NAME,
          AllegroFlare::Prototypes::FixedRoom2D::EventNames::SCRIPT_EVENT_NAME,
@@ -163,17 +158,19 @@ functions:
     body: |
       AllegroFlare::Prototypes::FixedRoom2D::EntityFactory entity_factory(bitmap_bin);
       AllegroFlare::Prototypes::FixedRoom2D::RoomFactory room_factory(
-         bitmap_bin, font_bin, event_emitter, &entity_dictionary
+         bitmap_bin, font_bin, event_emitter, &entity_dictionary, &entity_room_associations
       );
 
       room_dictionary = {
          { "front_hall", room_factory.create_room() },
-         //{ "study", room_factory.create_room() },
+         { "study", room_factory.create_room() },
       };
 
       entity_dictionary = {
-         { "door", entity_factory.create_entity(
-               "download-door-png-transparent-image-and-clipart-3.png", 1400, 800, 0.85, "Door", "observe_door") },
+         { "door1", entity_factory.create_entity(
+               "download-door-png-transparent-image-and-clipart-3.png", 1400, 800, 0.85, "Door 1", "observe_door1") },
+         { "door2", entity_factory.create_entity(
+               "download-door-png-transparent-image-and-clipart-3.png", 500, 800, 0.85, "Door 2", "observe_door2") },
          { "chair", entity_factory.create_entity(
                "wooden-chair-png-transparent-image-pngpix-0.png", 600, 800, 0.168, "Chair", "signal_hello") },
          { "table", entity_factory.create_entity(
@@ -183,15 +180,21 @@ functions:
       };
 
       entity_room_associations = {
-         { "door", "front_hall" },
+         { "door1", "front_hall" },
+         { "door2", "study" },
          { "chair", "front_hall" },
          { "table", "front_hall" },
          { "keys", "front_hall" },
       };
 
       script_dictionary = {
-         { "observe_door", AllegroFlare::Prototypes::FixedRoom2D::Script({
-               "DIALOG: Just a regular door. | It appears to be locked, though."
+         { "observe_door1", AllegroFlare::Prototypes::FixedRoom2D::Script({
+               //"DIALOG: Just a regular door. | I'm going to step through it.",
+               "ENTER_ROOM: study",
+         })},
+         { "observe_door2", AllegroFlare::Prototypes::FixedRoom2D::Script({
+               //"DIALOG: A regular door. | I'll to in.",
+               "ENTER_ROOM: front_hall",
          })},
          { "signal_hello", AllegroFlare::Prototypes::FixedRoom2D::Script({
                "SIGNAL: Hello!"})
@@ -208,6 +211,7 @@ functions:
       };
 
       enter_room("front_hall");
+      //enter_room("study");
 
       return;
 
@@ -216,11 +220,15 @@ functions:
     guards: [ initialized ]
     body: |
       //room.update();
+      std::cout << "AAA" << std::endl;
       update_all_rooms();
+      std::cout << "BBB" << std::endl;
 
       if (active_dialog) active_dialog->update();
+      std::cout << "CCC" << std::endl;
 
       inventory_window.update();
+      std::cout << "DDD" << std::endl;
       return;
 
 
@@ -239,6 +247,7 @@ functions:
          // TODO error message, "attempted to enter room named ... did not exist"
          return false;
       }
+      std::cout << "SETTING current room" << std::endl;
       current_room = it->second;
       return true;
 
@@ -246,12 +255,18 @@ functions:
   - name: render
     guards: [ initialized ]
     body: |
+      std::cout << "A" << std::endl;
       // render the current room
-      if (current_room) current_room->render();
+      if (current_room)
+      {
+         render_entities_in_current_room();
+         current_room->render(); // for now, only renders the cursor
+      }
       else
       {
          // TODO render_void_room();
       }
+      std::cout << "B" << std::endl;
 
       // render the active dialog
       if (active_dialog)
@@ -262,6 +277,7 @@ functions:
 
       // render the inventory window
       inventory_window.render();
+      std::cout << "C" << std::endl;
 
       return;
     body_dependency_symbols:
@@ -345,6 +361,8 @@ functions:
     body: |
       using namespace AllegroFlare::Prototypes::FixedRoom2D;
 
+      std::cout << "AAAAAAAA" << std::endl;
+
       if (!game_event_data)
       {
          // weird error;
@@ -365,6 +383,25 @@ functions:
             active_dialog = dialog_box_factory.create_basic_dialog(pages);
             //room.suspend();
             suspend_all_rooms();
+         }
+         if (game_event_data->get_type() == "EnterRoom")
+         {
+            std::cout << "EnterRoom AAAAAAAA" << std::endl;
+            AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::EnterRoom* enter_room_event_data =
+                static_cast<AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::EnterRoom*>(game_event_data);
+            //std::vector<std::string> pages = spawn_dialog_event_data->get_dialog_pages();
+            std::cout << "EnterRoom BBBBB" << std::endl;
+            std::string room_name_to_enter = enter_room_event_data->get_room_dictionary_name_to_enter();
+            std::cout << "EnterRoom CCCC" << std::endl;
+
+            enter_room(room_name_to_enter);
+            std::cout << "EnterRoom DDDD" << std::endl;
+            //AllegroFlare::Elements::DialogBoxFactory dialog_box_factory;
+            //if (active_dialog) delete active_dialog;
+
+            //active_dialog = dialog_box_factory.create_basic_dialog(pages);
+            //room.suspend();
+            //suspend_all_rooms();
          }
          if (game_event_data->get_type() == "CollectItem")
          {
@@ -393,7 +430,59 @@ functions:
     body_dependency_symbols:
       - AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::SpawnDialog
       - AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::CollectItem
+      - AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::EnterRoom
 
+
+  - name: render_entities_in_current_room
+    body: |
+      std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> entities =
+          get_entities_in_current_room();
+      // TODO: check
+      for (auto &entity : entities)
+      {
+         if (entity) entity->render();
+      }
+      
+      return;
+
+
+  - name: get_entities_in_current_room
+    type: std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>
+    body: |
+      std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> result;
+      std::vector<std::string> entity_names_in_current_room;
+      std::string current_room_name = get_dictionary_name_of_current_room();
+
+      for (auto &entity_room_association : entity_room_associations)
+      {
+         if (entity_room_association.second == current_room_name)
+         {
+            entity_names_in_current_room.push_back(entity_room_association.first);
+         }
+         //if (current_room == room_dictionary_listing.second) return room_dictionary_listing.first;
+      }
+
+      for (auto &entity_name_in_current_room : entity_names_in_current_room)
+      {
+         if (entity_dictionary.find(entity_name_in_current_room) != entity_dictionary.end())
+         {
+            result.push_back(entity_dictionary.at(entity_name_in_current_room));
+         }
+      }
+
+      return result;
+
+
+  - name: get_dictionary_name_of_current_room
+    type: std::string
+    body: |
+      if (!current_room) return "";
+      //if (current_room->empty()) return "";
+      for (auto &room_dictionary_listing : room_dictionary)
+      {
+         if (current_room == room_dictionary_listing.second) return room_dictionary_listing.first;
+      }
+      return "";
 
 
   - name: update_all_rooms
@@ -637,11 +726,15 @@ dependencies:
     headers: [ AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/SpawnDialog.hpp ]
   - symbol: AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::CollectItem
     headers: [ AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/CollectItem.hpp ]
+  - symbol: AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::EnterRoom
+    headers: [ AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/EnterRoom.hpp ]
   - symbol: AllegroFlare::GameEvent*
     headers: [ AllegroFlare/GameEvent.hpp ]
   - symbol: AllegroFlare::Prototypes::FixedRoom2D::EventNames::*
     headers: [ AllegroFlare/Prototypes/FixedRoom2D/EventNames.hpp ]
   - symbol: AllegroFlare::Prototypes::FixedRoom2D::RoomFactory
     headers: [ AllegroFlare/Prototypes/FixedRoom2D/RoomFactory.hpp ]
+  - symbol: std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>
+    headers: [ vector, AllegroFlare/Prototypes/FixedRoom2D/Entities/Base.hpp ]
 
   

--- a/quintessence/AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D.q.yml
+++ b/quintessence/AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D.q.yml
@@ -137,6 +137,7 @@ functions:
       inventory_window.set_af_inventory(&af_inventory);
 
       entity_collection_helper.set_entity_dictionary(&entity_dictionary);
+      entity_collection_helper.set_entity_room_associations(&entity_room_associations);
 
       script_runner.set_audio_controller(audio_controller);
       script_runner.set_af_inventory(&af_inventory);
@@ -158,7 +159,7 @@ functions:
     body: |
       AllegroFlare::Prototypes::FixedRoom2D::EntityFactory entity_factory(bitmap_bin);
       AllegroFlare::Prototypes::FixedRoom2D::RoomFactory room_factory(
-         bitmap_bin, font_bin, event_emitter, &entity_dictionary, &entity_room_associations
+         bitmap_bin, font_bin, event_emitter, &entity_collection_helper
       );
 
       room_dictionary = {
@@ -220,15 +221,11 @@ functions:
     guards: [ initialized ]
     body: |
       //room.update();
-      std::cout << "AAA" << std::endl;
       update_all_rooms();
-      std::cout << "BBB" << std::endl;
 
       if (active_dialog) active_dialog->update();
-      std::cout << "CCC" << std::endl;
 
       inventory_window.update();
-      std::cout << "DDD" << std::endl;
       return;
 
 
@@ -240,22 +237,82 @@ functions:
     type: bool
     guards: [ initialized ]
     body: |
+      // find the room name
       std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Room*>::iterator it =
          room_dictionary.find(room_name);
+
+      // if the room name does not exist, output an error and return false
       if (it == room_dictionary.end())
       {
-         // TODO error message, "attempted to enter room named ... did not exist"
+         std::cout << "[FixedRoom2D::FixedRoom2D::enter_room]: error: attempted to enter room named "
+                   << "\"" << room_name << "\" but it did not exist." << std::endl;
          return false;
       }
-      std::cout << "SETTING current room" << std::endl;
+
+      // output a nice little error showing that the room will be entered
+      std::cout << "[FixedRoom2D::FixedRoom2D::enter_room]: info: entering room named "
+                << "\"" << room_name << "\"." << std::endl;
+
+      // ensure all the entities do not think they have the cursor over them
+      unhover_any_and_all_entities();
+      reset_cursors_to_default_in_all_rooms();
+
+      // set the current room
       current_room = it->second;
+
       return true;
+
+
+  - name: unhover_any_and_all_entities
+    body: |
+      std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> all_entities =
+         entity_collection_helper.select_all();
+
+      for (auto &entity : all_entities)
+      {
+         if (entity->get_cursor_is_over()) entity->on_cursor_leave(); // TODO, consider exiting without "leaving"
+      }
+      return;
+
+
+  - name: reset_cursors_to_default_in_all_rooms
+    body: |
+      for (auto &room_dictionary_listing : room_dictionary)
+      {
+         AllegroFlare::Prototypes::FixedRoom2D::Room* room = room_dictionary_listing.second;
+         if (!room)
+         {
+            std::string room_name = room_dictionary_listing.first;
+            std::cout << "Odd error, when clearing cursors, room listing at \"" << room_name << "\" it is nullptr."
+                      << " Skipping." << std::endl;
+         }
+         else
+         {
+            room->reset_cursor_to_default();
+         }
+      }
+      return;
+
+
+  - name: get_current_room_dictionary_name
+    guards: [ initialized ]
+    type: std::string
+    parameters:
+      - name: room
+        type: AllegroFlare::Prototypes::FixedRoom2D::Room*
+        default_argument: nullptr
+    body: |
+      if (!current_room) return nullptr;
+      for (auto &room_dictionary_listing : room_dictionary)
+      {
+         if (room_dictionary_listing.second == room) return room_dictionary_listing.first;
+      }
+      return "";
 
 
   - name: render
     guards: [ initialized ]
     body: |
-      std::cout << "A" << std::endl;
       // render the current room
       if (current_room)
       {
@@ -266,7 +323,6 @@ functions:
       {
          // TODO render_void_room();
       }
-      std::cout << "B" << std::endl;
 
       // render the active dialog
       if (active_dialog)
@@ -277,7 +333,6 @@ functions:
 
       // render the inventory window
       inventory_window.render();
-      std::cout << "C" << std::endl;
 
       return;
     body_dependency_symbols:
@@ -361,8 +416,6 @@ functions:
     body: |
       using namespace AllegroFlare::Prototypes::FixedRoom2D;
 
-      std::cout << "AAAAAAAA" << std::endl;
-
       if (!game_event_data)
       {
          // weird error;
@@ -384,18 +437,14 @@ functions:
             //room.suspend();
             suspend_all_rooms();
          }
-         if (game_event_data->get_type() == "EnterRoom")
+         else if (game_event_data->get_type() == "EnterRoom")
          {
-            std::cout << "EnterRoom AAAAAAAA" << std::endl;
             AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::EnterRoom* enter_room_event_data =
                 static_cast<AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::EnterRoom*>(game_event_data);
             //std::vector<std::string> pages = spawn_dialog_event_data->get_dialog_pages();
-            std::cout << "EnterRoom BBBBB" << std::endl;
             std::string room_name_to_enter = enter_room_event_data->get_room_dictionary_name_to_enter();
-            std::cout << "EnterRoom CCCC" << std::endl;
 
             enter_room(room_name_to_enter);
-            std::cout << "EnterRoom DDDD" << std::endl;
             //AllegroFlare::Elements::DialogBoxFactory dialog_box_factory;
             //if (active_dialog) delete active_dialog;
 
@@ -403,7 +452,7 @@ functions:
             //room.suspend();
             //suspend_all_rooms();
          }
-         if (game_event_data->get_type() == "CollectItem")
+         else if (game_event_data->get_type() == "CollectItem")
          {
             AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::CollectItem* collect_item_event_data =
                 static_cast<AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::CollectItem*>(game_event_data);
@@ -674,7 +723,10 @@ functions:
     body: |
       if (current_room && !current_room->get_suspended())
       { 
-         current_room->move_cursor(distance_x, distance_y);
+         std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> entities_in_current_room =
+             get_entities_in_current_room();
+         //std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> entities_in_this_room = 
+         current_room->move_cursor(distance_x, distance_y, entities_in_current_room);
       }
       return;
 

--- a/quintessence/AllegroFlare/Prototypes/FixedRoom2D/Room.q.yml
+++ b/quintessence/AllegroFlare/Prototypes/FixedRoom2D/Room.q.yml
@@ -55,6 +55,18 @@ functions:
       return;
 
 
+  - name: set_entity_room_associations
+    type: void
+    parameters:
+      - name: entity_room_associations
+        type: std::map<std::string, std::string>*
+        default_argument: nullptr
+    body: |
+      //this->entity_dictionary = entity_dictionary;
+      //entity_collection_helper.set_entity_room_associations(entity_dictionary);
+      return;
+
+
   - name: suspend
     guards: [ initialized ]
     body: |
@@ -104,10 +116,10 @@ functions:
       if (suspended) return;
 
       // update the entities
-      for (auto &entity : entity_collection_helper.select_all_ordered_by_id())
-      {
-         entity->update();
-      }
+      //for (auto &entity : entity_collection_helper.select_all_ordered_by_id())
+      //{
+         //entity->update();
+      //}
 
       // update the cursor
       cursor.update();
@@ -117,13 +129,18 @@ functions:
 
   - name: render
     guards: [ initialized ]
+    parameters:
+      - name: this_rooms_dictionary_name__this_injection_is_temporary_measure
+        type: std::string
+        default_argument: '"[unset-this_rooms_dictionary_name__this_injection_is_temporary_measure]"'
     body: |
       // draw the entities
-      for (auto &entity : entity_collection_helper.select_all_ordered_by_id())
-      {
-         entity->render();
+      //for (auto &entity : entity_collection_helper.select_all_ordered_by_id(
+      //   this_rooms_dictionary_name__this_injection_is_temporary_measure))
+      //{
+         //entity->render();
          //entity->get_placement_ref().draw_box(AllegroFlare::Color::DodgerBlue, true);
-      }
+      //}
 
       // draw the cursor
       cursor.draw();
@@ -248,6 +265,7 @@ dependencies:
     headers: [ AllegroFlare/Prototypes/FixedRoom2D/InteractionEventData.hpp ]
   - symbol: AllegroFlare::Prototypes::FixedRoom2D::EventNames::INTERACTION_EVENT_NAME
     headers: [ AllegroFlare/Prototypes/FixedRoom2D/EventNames.hpp ]
-
+  - symbol: std::map<std::string, std::string>*
+    headers: [ map, string ]
 
   

--- a/quintessence/AllegroFlare/Prototypes/FixedRoom2D/Room.q.yml
+++ b/quintessence/AllegroFlare/Prototypes/FixedRoom2D/Room.q.yml
@@ -13,14 +13,11 @@ properties:
     constructor_arg: true
     setter: true
 
-  - name: entity_dictionary
-    type: std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>*
+  - name: entity_collection_helper
+    type: AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper*
     init_with: nullptr
     constructor_arg: true
-
-  - name: entity_collection_helper
-    type: AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper
-    init_with: entity_dictionary
+    setter: true
 
   - name: cursor
     type: AllegroFlare::Prototypes::FixedRoom2D::Cursor
@@ -41,30 +38,6 @@ properties:
 
 
 functions:
-
-
-  - name: set_entity_dictionary
-    type: void
-    parameters:
-      - name: entity_dictionary
-        type: std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>*
-        default_argument: nullptr
-    body: |
-      this->entity_dictionary = entity_dictionary;
-      entity_collection_helper.set_entity_dictionary(entity_dictionary);
-      return;
-
-
-  - name: set_entity_room_associations
-    type: void
-    parameters:
-      - name: entity_room_associations
-        type: std::map<std::string, std::string>*
-        default_argument: nullptr
-    body: |
-      //this->entity_dictionary = entity_dictionary;
-      //entity_collection_helper.set_entity_room_associations(entity_dictionary);
-      return;
 
 
   - name: suspend
@@ -148,13 +121,13 @@ functions:
       return;
     body_dependency_symbols:
       - AllegroFlare::Color::*
-      - AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper
+      - AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper*
 
 
   - name: interact_with_item_under_cursor
-    guards: [ initialized, event_emitter ]
+    guards: [ initialized, event_emitter, entity_collection_helper ]
     body: |
-      std::string name = entity_collection_helper.find_dictionary_name_of_entity_that_cursor_is_now_over();
+      std::string name = entity_collection_helper->find_dictionary_name_of_entity_that_cursor_is_now_over();
       emit_interaction_event(name, cursor.get_x(), cursor.get_y());
       return;
 
@@ -168,6 +141,10 @@ functions:
       - name: distance_y
         type: float
         default_argument: 0.0
+      - name: entities_in_this_room
+        type: std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>
+        default_argument: '{}'
+    guards: [ entity_collection_helper ]
     body: |
       cursor.move(distance_x, distance_y);
 
@@ -178,7 +155,7 @@ functions:
       int cursor_y = cursor.get_y();
 
       // update the state of the entities
-      for (auto &entity : entity_collection_helper.select_all_ordered_by_id())
+      for (auto &entity : entities_in_this_room)
       {
          if (entity->get_cursor_is_over()) entity_cursor_was_over = entity;
          if (entity->get_placement_ref().collide(cursor_x, cursor_y)) entity_cursor_is_now_over = entity;
@@ -201,11 +178,17 @@ functions:
          else
          {
             // cursor is now over nothing
-            cursor.set_cursor_to_pointer();
-            cursor.clear_info_text();
+            reset_cursor_to_default();
          }
       }
 
+      return;
+
+
+  - name: reset_cursor_to_default
+    body: |
+      cursor.set_cursor_to_pointer();
+      cursor.clear_info_text();
       return;
 
 
@@ -255,7 +238,7 @@ dependencies:
     headers: [ AllegroFlare/Prototypes/FixedRoom2D/RoomDictionary.hpp ]
   - symbol: std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>*
     headers: [ AllegroFlare/Prototypes/FixedRoom2D/Entities/Base.hpp ]
-  - symbol: AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper
+  - symbol: AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper*
     headers: [ AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.hpp ]
   - symbol: std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Script>
     headers: [ map, AllegroFlare/Prototypes/FixedRoom2D/Script.hpp ]
@@ -267,5 +250,7 @@ dependencies:
     headers: [ AllegroFlare/Prototypes/FixedRoom2D/EventNames.hpp ]
   - symbol: std::map<std::string, std::string>*
     headers: [ map, string ]
+  - symbol: std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>
+    headers: [ vector, AllegroFlare/Prototypes/FixedRoom2D/Entities/Base.hpp ]
 
   

--- a/quintessence/AllegroFlare/Prototypes/FixedRoom2D/RoomFactory.q.yml
+++ b/quintessence/AllegroFlare/Prototypes/FixedRoom2D/RoomFactory.q.yml
@@ -16,15 +16,11 @@ properties:
     init_with: nullptr
     constructor_arg: true
 
-  - name: entity_dictionary
-    type: std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>*
+  - name: entity_collection_helper
+    type: AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper*
     init_with: nullptr
     constructor_arg: true
 
-  - name: entity_room_associations
-    type: std::map<std::string, std::string>*
-    init_with: nullptr
-    constructor_arg: true
 
 functions:
 
@@ -38,13 +34,10 @@ functions:
       - name: height
         type: float
         default_argument: (1080-200)
-    guards: [ bitmap_bin, font_bin, event_emitter, entity_dictionary, entity_room_associations ]
+    guards: [ bitmap_bin, font_bin, event_emitter, entity_collection_helper ]
     body: |
       AllegroFlare::Prototypes::FixedRoom2D::Room* result =
-         new AllegroFlare::Prototypes::FixedRoom2D::Room(font_bin, event_emitter);
-
-      result->set_entity_dictionary(entity_dictionary);
-      result->set_entity_room_associations(entity_room_associations);
+         new AllegroFlare::Prototypes::FixedRoom2D::Room(font_bin, event_emitter, entity_collection_helper);
       result->initialize();
 
       return result;
@@ -65,5 +58,7 @@ dependencies:
     headers: [ map, string, AllegroFlare/Prototypes/FixedRoom2D/Entities/Base.hpp ]
   - symbol: std::map<std::string, std::string>*
     headers: [ map, string ]
+  - symbol: AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper*
+    headers: [ AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.hpp ]
 
 

--- a/quintessence/AllegroFlare/Prototypes/FixedRoom2D/RoomFactory.q.yml
+++ b/quintessence/AllegroFlare/Prototypes/FixedRoom2D/RoomFactory.q.yml
@@ -21,6 +21,10 @@ properties:
     init_with: nullptr
     constructor_arg: true
 
+  - name: entity_room_associations
+    type: std::map<std::string, std::string>*
+    init_with: nullptr
+    constructor_arg: true
 
 functions:
 
@@ -34,12 +38,13 @@ functions:
       - name: height
         type: float
         default_argument: (1080-200)
-    guards: [ bitmap_bin, font_bin, event_emitter, entity_dictionary ]
+    guards: [ bitmap_bin, font_bin, event_emitter, entity_dictionary, entity_room_associations ]
     body: |
       AllegroFlare::Prototypes::FixedRoom2D::Room* result =
          new AllegroFlare::Prototypes::FixedRoom2D::Room(font_bin, event_emitter);
 
       result->set_entity_dictionary(entity_dictionary);
+      result->set_entity_room_associations(entity_room_associations);
       result->initialize();
 
       return result;
@@ -58,5 +63,7 @@ dependencies:
     headers: [ AllegroFlare/EventEmitter.hpp ]
   - symbol: std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>*
     headers: [ map, string, AllegroFlare/Prototypes/FixedRoom2D/Entities/Base.hpp ]
+  - symbol: std::map<std::string, std::string>*
+    headers: [ map, string ]
 
 

--- a/quintessence/AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/EnterRoom.q.yml
+++ b/quintessence/AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/EnterRoom.q.yml
@@ -1,0 +1,26 @@
+parent_classes:
+
+
+  - class: AllegroFlare::GameEventDatas::Base
+    scope: public
+    init_with: '"EnterRoom"'
+
+
+properties:
+
+
+  - name: room_dictionary_name_to_enter
+    type: std::string
+    init_with: '"[unset-room_dictionary_name_to_enter]"'
+    constructor_arg: true
+    getter: true
+    setter: true
+
+
+dependencies:
+
+
+  - symbol: AllegroFlare::GameEventDatas::Base
+    headers: [ AllegroFlare/GameEventDatas/Base.hpp ]
+
+

--- a/quintessence/AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner.q.yml
+++ b/quintessence/AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner.q.yml
@@ -184,22 +184,18 @@ functions:
       }
       else if (command == ENTER_ROOM)
       {
-         std::cout << "processing ENTER_ROOM" << std::endl;
          std::vector<std::string> tokens = tokenize(argument);
          if (!assert_token_count_eq(tokens, 1))
          {
             std::cout << "ENTER_ROOM - expecting 1 and only 1 argument on line " << line_num << std::endl;
             return false;
          }
-         std::cout << "processing ENTER_ROOM BBB" << std::endl;
 
          std::string room_name = tokens[0];
-         std::cout << "processing ENTER_ROOM CCC" << std::endl;
 
          AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::EnterRoom *enter_room_event_datas =
             new AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::EnterRoom(room_name);
          emit_script_event(enter_room_event_datas);
-         std::cout << "processing ENTER_ROOM DDD" << std::endl;
       }
       else if (command == PLAY_MUSIC)
       {

--- a/quintessence/AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner.q.yml
+++ b/quintessence/AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner.q.yml
@@ -138,14 +138,17 @@ functions:
     body: |
       std::string DIALOG = "DIALOG";
       std::string GOTO_MARKER = "GOTO_MARKER";
-      std::string CHOICE = "CHOICE";
-      std::string PLAY_MUSIC = "PLAY_MUSIC";
+      std::string ENTER_ROOM = "ENTER_ROOM";
       std::string MARKER = "MARKER";
       std::string SIGNAL = "SIGNAL"; // outputs text to the terminal
+      std::string COLLECT = "COLLECT";
+
+
+      std::string CHOICE = "CHOICE";
+      std::string PLAY_MUSIC = "PLAY_MUSIC";
       std::string SET_CHARACTER_ART = "SET_CHARACTER_ART";
       std::string BEAT = "BEAT";
       std::string WAIT = "WAIT";
-      std::string COLLECT = "COLLECT";
       std::string COLLECT_SILENTLY = "COLLECT_SILENTLY";
       std::string IF_IN_INVENTORY = "IF_IN_INVENTORY";
       std::string ADD_FLAG = "ADD_FLAG";
@@ -178,6 +181,25 @@ functions:
             emit_script_event(spawn_dialog_event_data);
             //Disabled:: created_dialog = dialog_factory.create_basic_dialog(std::vector<std::string>{script_line});
          }
+      }
+      else if (command == ENTER_ROOM)
+      {
+         std::cout << "processing ENTER_ROOM" << std::endl;
+         std::vector<std::string> tokens = tokenize(argument);
+         if (!assert_token_count_eq(tokens, 1))
+         {
+            std::cout << "ENTER_ROOM - expecting 1 and only 1 argument on line " << line_num << std::endl;
+            return false;
+         }
+         std::cout << "processing ENTER_ROOM BBB" << std::endl;
+
+         std::string room_name = tokens[0];
+         std::cout << "processing ENTER_ROOM CCC" << std::endl;
+
+         AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::EnterRoom *enter_room_event_datas =
+            new AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::EnterRoom(room_name);
+         emit_script_event(enter_room_event_datas);
+         std::cout << "processing ENTER_ROOM DDD" << std::endl;
       }
       else if (command == PLAY_MUSIC)
       {
@@ -497,6 +519,7 @@ functions:
     body_dependency_symbols:
       - AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::SpawnDialog
       - AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::CollectItem
+      - AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::EnterRoom
 
 
   - name: parse_command_and_argument
@@ -679,5 +702,7 @@ dependencies:
     headers: [ AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/SpawnDialog.hpp ]
   - symbol: AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::CollectItem
     headers: [ AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/CollectItem.hpp ]
+  - symbol: AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::EnterRoom
+    headers: [ AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/EnterRoom.hpp ]
 
 

--- a/src/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.cpp
+++ b/src/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.cpp
@@ -17,6 +17,8 @@
 #include <sstream>
 #include <stdexcept>
 #include <sstream>
+#include <stdexcept>
+#include <sstream>
 
 
 namespace AllegroFlare
@@ -110,12 +112,12 @@ std::string EntityCollectionHelper::find_dictionary_name_of_entity_that_cursor_i
    return "";
 }
 
-AllegroFlare::Prototypes::FixedRoom2D::Entities::Base* EntityCollectionHelper::find_by_dictionary_listing_name(std::string dictionary_listing_name)
+AllegroFlare::Prototypes::FixedRoom2D::Entities::Base* EntityCollectionHelper::find_entity_by_dictionary_name(std::string dictionary_listing_name)
 {
    if (!(entity_dictionary))
       {
          std::stringstream error_message;
-         error_message << "EntityCollectionHelper" << "::" << "find_by_dictionary_listing_name" << ": error: " << "guard \"entity_dictionary\" not met";
+         error_message << "EntityCollectionHelper" << "::" << "find_entity_by_dictionary_name" << ": error: " << "guard \"entity_dictionary\" not met";
          throw std::runtime_error(error_message.str());
       }
    std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>::iterator it =
@@ -145,6 +147,20 @@ std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> EntityCollec
       result.push_back(entity.second);
    }
    return result;
+}
+
+void EntityCollectionHelper::get_entities_from_entity_names(std::vector<std::string> entity_names)
+{
+   if (!(entity_dictionary))
+      {
+         std::stringstream error_message;
+         error_message << "EntityCollectionHelper" << "::" << "get_entities_from_entity_names" << ": error: " << "guard \"entity_dictionary\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   {
+      
+   }
+   return;
 }
 
 std::vector<std::string> EntityCollectionHelper::select_all_entity_names_in_room_name(std::string room_name)

--- a/src/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.cpp
+++ b/src/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.cpp
@@ -13,6 +13,8 @@
 #include <sstream>
 #include <map>
 #include <AllegroFlare/Prototypes/FixedRoom2D/Entities/Base.hpp>
+#include <map>
+#include <AllegroFlare/Prototypes/FixedRoom2D/Entities/Base.hpp>
 #include <stdexcept>
 #include <sstream>
 #include <stdexcept>
@@ -126,6 +128,24 @@ AllegroFlare::Prototypes::FixedRoom2D::Entities::Base* EntityCollectionHelper::f
    return it->second;
 }
 
+std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> EntityCollectionHelper::order_by_id(std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> entities_to_order)
+{
+   std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> result;
+   std::map<int, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> as_ids;
+
+   for (auto &entity : entities_to_order)
+   {
+      if (!entity) continue;
+      as_ids[entity->get_id()] = entity;
+   }
+
+   for (auto &entity : as_ids)
+   {
+      result.push_back(entity.second);
+   }
+   return result;
+}
+
 std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> EntityCollectionHelper::select_all_ordered_by_id(std::string room_name)
 {
    if (!(entity_dictionary))
@@ -149,18 +169,32 @@ std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> EntityCollec
    return result;
 }
 
-void EntityCollectionHelper::get_entities_from_entity_names(std::vector<std::string> entity_names)
+std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> EntityCollectionHelper::get_entities_by_entity_names(std::vector<std::string> entity_dictionary_names)
 {
    if (!(entity_dictionary))
       {
          std::stringstream error_message;
-         error_message << "EntityCollectionHelper" << "::" << "get_entities_from_entity_names" << ": error: " << "guard \"entity_dictionary\" not met";
+         error_message << "EntityCollectionHelper" << "::" << "get_entities_by_entity_names" << ": error: " << "guard \"entity_dictionary\" not met";
          throw std::runtime_error(error_message.str());
       }
+   std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> result;
+   for (auto &entity_dictionary_name : entity_dictionary_names)
    {
-      
+      AllegroFlare::Prototypes::FixedRoom2D::Entities::Base* found_entity =
+         find_entity_by_dictionary_name(entity_dictionary_name);
+
+      if (!found_entity)
+      {
+         std::cout << "[FixedRoom2D::EntityCollectionHelper::get_entities_from_entity_names]: warning: The provided "
+                   << "entity name \"" << entity_dictionary_name << "\" does not have a listing. Ignoring."
+                   << std::endl;
+      }
+      else
+      {
+         result.push_back(found_entity);
+      }
    }
-   return;
+   return result;
 }
 
 std::vector<std::string> EntityCollectionHelper::select_all_entity_names_in_room_name(std::string room_name)

--- a/src/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.cpp
+++ b/src/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.cpp
@@ -13,10 +13,6 @@
 #include <sstream>
 #include <map>
 #include <AllegroFlare/Prototypes/FixedRoom2D/Entities/Base.hpp>
-#include <map>
-#include <AllegroFlare/Prototypes/FixedRoom2D/Entities/Base.hpp>
-#include <stdexcept>
-#include <sstream>
 #include <stdexcept>
 #include <sstream>
 #include <stdexcept>
@@ -67,35 +63,30 @@ std::map<std::string, std::string>* EntityCollectionHelper::get_entity_room_asso
 }
 
 
-std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> EntityCollectionHelper::select_all_in_room(std::string room_name)
+std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> EntityCollectionHelper::select_all_in_room_ordered_by_id(std::string room_name)
 {
    if (!(entity_dictionary))
       {
          std::stringstream error_message;
-         error_message << "EntityCollectionHelper" << "::" << "select_all_in_room" << ": error: " << "guard \"entity_dictionary\" not met";
+         error_message << "EntityCollectionHelper" << "::" << "select_all_in_room_ordered_by_id" << ": error: " << "guard \"entity_dictionary\" not met";
          throw std::runtime_error(error_message.str());
       }
-   std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> result;
-   for (auto &entity : *entity_dictionary)
-   {
-      // if entity has the attribute, include it in the result
-   }
-   return result;
+   std::vector<std::string> entity_names_in_room = select_all_entity_names_in_room_name(room_name);
+   std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> entities =
+      get_entities_by_entity_names(entity_names_in_room);
+   return order_by_id(entities);
 }
 
-std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> EntityCollectionHelper::select_all_unordered()
+std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> EntityCollectionHelper::select_all()
 {
    if (!(entity_dictionary))
       {
          std::stringstream error_message;
-         error_message << "EntityCollectionHelper" << "::" << "select_all_unordered" << ": error: " << "guard \"entity_dictionary\" not met";
+         error_message << "EntityCollectionHelper" << "::" << "select_all" << ": error: " << "guard \"entity_dictionary\" not met";
          throw std::runtime_error(error_message.str());
       }
    std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> result;
-   for (auto &entity : *entity_dictionary)
-   {
-      result.push_back(entity.second);
-   }
+   for (auto &entity : *entity_dictionary) { result.push_back(entity.second); }
    return result;
 }
 
@@ -137,29 +128,6 @@ std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> EntityCollec
    {
       if (!entity) continue;
       as_ids[entity->get_id()] = entity;
-   }
-
-   for (auto &entity : as_ids)
-   {
-      result.push_back(entity.second);
-   }
-   return result;
-}
-
-std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> EntityCollectionHelper::select_all_ordered_by_id(std::string room_name)
-{
-   if (!(entity_dictionary))
-      {
-         std::stringstream error_message;
-         error_message << "EntityCollectionHelper" << "::" << "select_all_ordered_by_id" << ": error: " << "guard \"entity_dictionary\" not met";
-         throw std::runtime_error(error_message.str());
-      }
-   std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> result;
-   std::map<int, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> as_ids;
-
-   for (auto &entity : *entity_dictionary)
-   {
-      as_ids[entity.second->get_id()] = entity.second;
    }
 
    for (auto &entity : as_ids)

--- a/src/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.cpp
+++ b/src/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.cpp
@@ -15,6 +15,8 @@
 #include <AllegroFlare/Prototypes/FixedRoom2D/Entities/Base.hpp>
 #include <stdexcept>
 #include <sstream>
+#include <stdexcept>
+#include <sstream>
 
 
 namespace AllegroFlare
@@ -25,8 +27,9 @@ namespace FixedRoom2D
 {
 
 
-EntityCollectionHelper::EntityCollectionHelper(std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>* entity_dictionary)
+EntityCollectionHelper::EntityCollectionHelper(std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>* entity_dictionary, std::map<std::string, std::string>* entity_room_associations)
    : entity_dictionary(entity_dictionary)
+   , entity_room_associations(entity_room_associations)
 {
 }
 
@@ -42,9 +45,21 @@ void EntityCollectionHelper::set_entity_dictionary(std::map<std::string, Allegro
 }
 
 
+void EntityCollectionHelper::set_entity_room_associations(std::map<std::string, std::string>* entity_room_associations)
+{
+   this->entity_room_associations = entity_room_associations;
+}
+
+
 std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>* EntityCollectionHelper::get_entity_dictionary()
 {
    return entity_dictionary;
+}
+
+
+std::map<std::string, std::string>* EntityCollectionHelper::get_entity_room_associations()
+{
+   return entity_room_associations;
 }
 
 
@@ -128,6 +143,22 @@ std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> EntityCollec
    for (auto &entity : as_ids)
    {
       result.push_back(entity.second);
+   }
+   return result;
+}
+
+std::vector<std::string> EntityCollectionHelper::select_all_entity_names_in_room_name(std::string room_name)
+{
+   if (!(entity_room_associations))
+      {
+         std::stringstream error_message;
+         error_message << "EntityCollectionHelper" << "::" << "select_all_entity_names_in_room_name" << ": error: " << "guard \"entity_room_associations\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   std::vector<std::string> result;
+   for (auto &entity_room_association : (*entity_room_associations))
+   {
+      if (entity_room_association.second == room_name) result.push_back(entity_room_association.first);
    }
    return result;
 }

--- a/src/AllegroFlare/Prototypes/FixedRoom2D/Room.cpp
+++ b/src/AllegroFlare/Prototypes/FixedRoom2D/Room.cpp
@@ -78,6 +78,13 @@ void Room::set_entity_dictionary(std::map<std::string, AllegroFlare::Prototypes:
    return;
 }
 
+void Room::set_entity_room_associations(std::map<std::string, std::string>* entity_room_associations)
+{
+   //this->entity_dictionary = entity_dictionary;
+   //entity_collection_helper.set_entity_room_associations(entity_dictionary);
+   return;
+}
+
 void Room::suspend()
 {
    if (!(initialized))
@@ -157,10 +164,10 @@ void Room::update()
    if (suspended) return;
 
    // update the entities
-   for (auto &entity : entity_collection_helper.select_all_ordered_by_id())
-   {
-      entity->update();
-   }
+   //for (auto &entity : entity_collection_helper.select_all_ordered_by_id())
+   //{
+      //entity->update();
+   //}
 
    // update the cursor
    cursor.update();
@@ -168,7 +175,7 @@ void Room::update()
    return;
 }
 
-void Room::render()
+void Room::render(std::string this_rooms_dictionary_name__this_injection_is_temporary_measure)
 {
    if (!(initialized))
       {
@@ -177,11 +184,12 @@ void Room::render()
          throw std::runtime_error(error_message.str());
       }
    // draw the entities
-   for (auto &entity : entity_collection_helper.select_all_ordered_by_id())
-   {
-      entity->render();
+   //for (auto &entity : entity_collection_helper.select_all_ordered_by_id(
+   //   this_rooms_dictionary_name__this_injection_is_temporary_measure))
+   //{
+      //entity->render();
       //entity->get_placement_ref().draw_box(AllegroFlare::Color::DodgerBlue, true);
-   }
+   //}
 
    // draw the cursor
    cursor.draw();

--- a/src/AllegroFlare/Prototypes/FixedRoom2D/Room.cpp
+++ b/src/AllegroFlare/Prototypes/FixedRoom2D/Room.cpp
@@ -35,11 +35,10 @@ namespace FixedRoom2D
 {
 
 
-Room::Room(AllegroFlare::FontBin* font_bin, AllegroFlare::EventEmitter* event_emitter, std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>* entity_dictionary)
+Room::Room(AllegroFlare::FontBin* font_bin, AllegroFlare::EventEmitter* event_emitter, AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper* entity_collection_helper)
    : font_bin(font_bin)
    , event_emitter(event_emitter)
-   , entity_dictionary(entity_dictionary)
-   , entity_collection_helper(entity_dictionary)
+   , entity_collection_helper(entity_collection_helper)
    , cursor({})
    , suspended(false)
    , suspended_at(0.0f)
@@ -65,25 +64,17 @@ void Room::set_event_emitter(AllegroFlare::EventEmitter* event_emitter)
 }
 
 
+void Room::set_entity_collection_helper(AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper* entity_collection_helper)
+{
+   this->entity_collection_helper = entity_collection_helper;
+}
+
+
 bool Room::get_suspended()
 {
    return suspended;
 }
 
-
-void Room::set_entity_dictionary(std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>* entity_dictionary)
-{
-   this->entity_dictionary = entity_dictionary;
-   entity_collection_helper.set_entity_dictionary(entity_dictionary);
-   return;
-}
-
-void Room::set_entity_room_associations(std::map<std::string, std::string>* entity_room_associations)
-{
-   //this->entity_dictionary = entity_dictionary;
-   //entity_collection_helper.set_entity_room_associations(entity_dictionary);
-   return;
-}
 
 void Room::suspend()
 {
@@ -211,12 +202,18 @@ void Room::interact_with_item_under_cursor()
          error_message << "Room" << "::" << "interact_with_item_under_cursor" << ": error: " << "guard \"event_emitter\" not met";
          throw std::runtime_error(error_message.str());
       }
-   std::string name = entity_collection_helper.find_dictionary_name_of_entity_that_cursor_is_now_over();
+   if (!(entity_collection_helper))
+      {
+         std::stringstream error_message;
+         error_message << "Room" << "::" << "interact_with_item_under_cursor" << ": error: " << "guard \"entity_collection_helper\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   std::string name = entity_collection_helper->find_dictionary_name_of_entity_that_cursor_is_now_over();
    emit_interaction_event(name, cursor.get_x(), cursor.get_y());
    return;
 }
 
-void Room::move_cursor(float distance_x, float distance_y)
+void Room::move_cursor(float distance_x, float distance_y, std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> entities_in_this_room)
 {
    if (!(initialized))
       {
@@ -233,7 +230,7 @@ void Room::move_cursor(float distance_x, float distance_y)
    int cursor_y = cursor.get_y();
 
    // update the state of the entities
-   for (auto &entity : entity_collection_helper.select_all_ordered_by_id())
+   for (auto &entity : entities_in_this_room)
    {
       if (entity->get_cursor_is_over()) entity_cursor_was_over = entity;
       if (entity->get_placement_ref().collide(cursor_x, cursor_y)) entity_cursor_is_now_over = entity;
@@ -256,11 +253,17 @@ void Room::move_cursor(float distance_x, float distance_y)
       else
       {
          // cursor is now over nothing
-         cursor.set_cursor_to_pointer();
-         cursor.clear_info_text();
+         reset_cursor_to_default();
       }
    }
 
+   return;
+}
+
+void Room::reset_cursor_to_default()
+{
+   cursor.set_cursor_to_pointer();
+   cursor.clear_info_text();
    return;
 }
 

--- a/src/AllegroFlare/Prototypes/FixedRoom2D/RoomFactory.cpp
+++ b/src/AllegroFlare/Prototypes/FixedRoom2D/RoomFactory.cpp
@@ -13,12 +13,11 @@ namespace FixedRoom2D
 {
 
 
-RoomFactory::RoomFactory(AllegroFlare::BitmapBin* bitmap_bin, AllegroFlare::FontBin* font_bin, AllegroFlare::EventEmitter* event_emitter, std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>* entity_dictionary, std::map<std::string, std::string>* entity_room_associations)
+RoomFactory::RoomFactory(AllegroFlare::BitmapBin* bitmap_bin, AllegroFlare::FontBin* font_bin, AllegroFlare::EventEmitter* event_emitter, AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper* entity_collection_helper)
    : bitmap_bin(bitmap_bin)
    , font_bin(font_bin)
    , event_emitter(event_emitter)
-   , entity_dictionary(entity_dictionary)
-   , entity_room_associations(entity_room_associations)
+   , entity_collection_helper(entity_collection_helper)
 {
 }
 
@@ -48,23 +47,14 @@ AllegroFlare::Prototypes::FixedRoom2D::Room* RoomFactory::create_room(float widt
          error_message << "RoomFactory" << "::" << "create_room" << ": error: " << "guard \"event_emitter\" not met";
          throw std::runtime_error(error_message.str());
       }
-   if (!(entity_dictionary))
+   if (!(entity_collection_helper))
       {
          std::stringstream error_message;
-         error_message << "RoomFactory" << "::" << "create_room" << ": error: " << "guard \"entity_dictionary\" not met";
-         throw std::runtime_error(error_message.str());
-      }
-   if (!(entity_room_associations))
-      {
-         std::stringstream error_message;
-         error_message << "RoomFactory" << "::" << "create_room" << ": error: " << "guard \"entity_room_associations\" not met";
+         error_message << "RoomFactory" << "::" << "create_room" << ": error: " << "guard \"entity_collection_helper\" not met";
          throw std::runtime_error(error_message.str());
       }
    AllegroFlare::Prototypes::FixedRoom2D::Room* result =
-      new AllegroFlare::Prototypes::FixedRoom2D::Room(font_bin, event_emitter);
-
-   result->set_entity_dictionary(entity_dictionary);
-   result->set_entity_room_associations(entity_room_associations);
+      new AllegroFlare::Prototypes::FixedRoom2D::Room(font_bin, event_emitter, entity_collection_helper);
    result->initialize();
 
    return result;

--- a/src/AllegroFlare/Prototypes/FixedRoom2D/RoomFactory.cpp
+++ b/src/AllegroFlare/Prototypes/FixedRoom2D/RoomFactory.cpp
@@ -13,11 +13,12 @@ namespace FixedRoom2D
 {
 
 
-RoomFactory::RoomFactory(AllegroFlare::BitmapBin* bitmap_bin, AllegroFlare::FontBin* font_bin, AllegroFlare::EventEmitter* event_emitter, std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>* entity_dictionary)
+RoomFactory::RoomFactory(AllegroFlare::BitmapBin* bitmap_bin, AllegroFlare::FontBin* font_bin, AllegroFlare::EventEmitter* event_emitter, std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*>* entity_dictionary, std::map<std::string, std::string>* entity_room_associations)
    : bitmap_bin(bitmap_bin)
    , font_bin(font_bin)
    , event_emitter(event_emitter)
    , entity_dictionary(entity_dictionary)
+   , entity_room_associations(entity_room_associations)
 {
 }
 
@@ -53,10 +54,17 @@ AllegroFlare::Prototypes::FixedRoom2D::Room* RoomFactory::create_room(float widt
          error_message << "RoomFactory" << "::" << "create_room" << ": error: " << "guard \"entity_dictionary\" not met";
          throw std::runtime_error(error_message.str());
       }
+   if (!(entity_room_associations))
+      {
+         std::stringstream error_message;
+         error_message << "RoomFactory" << "::" << "create_room" << ": error: " << "guard \"entity_room_associations\" not met";
+         throw std::runtime_error(error_message.str());
+      }
    AllegroFlare::Prototypes::FixedRoom2D::Room* result =
       new AllegroFlare::Prototypes::FixedRoom2D::Room(font_bin, event_emitter);
 
    result->set_entity_dictionary(entity_dictionary);
+   result->set_entity_room_associations(entity_room_associations);
    result->initialize();
 
    return result;

--- a/src/AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/EnterRoom.cpp
+++ b/src/AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/EnterRoom.cpp
@@ -1,0 +1,46 @@
+
+
+#include <AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/EnterRoom.hpp>
+
+
+
+namespace AllegroFlare
+{
+namespace Prototypes
+{
+namespace FixedRoom2D
+{
+namespace ScriptEventDatas
+{
+
+
+EnterRoom::EnterRoom(std::string room_dictionary_name_to_enter)
+   : AllegroFlare::GameEventDatas::Base("EnterRoom")
+   , room_dictionary_name_to_enter(room_dictionary_name_to_enter)
+{
+}
+
+
+EnterRoom::~EnterRoom()
+{
+}
+
+
+void EnterRoom::set_room_dictionary_name_to_enter(std::string room_dictionary_name_to_enter)
+{
+   this->room_dictionary_name_to_enter = room_dictionary_name_to_enter;
+}
+
+
+std::string EnterRoom::get_room_dictionary_name_to_enter()
+{
+   return room_dictionary_name_to_enter;
+}
+
+
+} // namespace ScriptEventDatas
+} // namespace FixedRoom2D
+} // namespace Prototypes
+} // namespace AllegroFlare
+
+

--- a/src/AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner.cpp
+++ b/src/AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/SpawnDialog.hpp>
 #include <AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/CollectItem.hpp>
+#include <AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/EnterRoom.hpp>
 #include <stdexcept>
 #include <sstream>
 #include <AllegroFlare/Prototypes/FixedRoom2D/EventNames.hpp>
@@ -198,14 +199,17 @@ bool ScriptRunner::parse_and_run_line(std::string raw_script_line, int line_num)
       }
    std::string DIALOG = "DIALOG";
    std::string GOTO_MARKER = "GOTO_MARKER";
-   std::string CHOICE = "CHOICE";
-   std::string PLAY_MUSIC = "PLAY_MUSIC";
+   std::string ENTER_ROOM = "ENTER_ROOM";
    std::string MARKER = "MARKER";
    std::string SIGNAL = "SIGNAL"; // outputs text to the terminal
+   std::string COLLECT = "COLLECT";
+
+
+   std::string CHOICE = "CHOICE";
+   std::string PLAY_MUSIC = "PLAY_MUSIC";
    std::string SET_CHARACTER_ART = "SET_CHARACTER_ART";
    std::string BEAT = "BEAT";
    std::string WAIT = "WAIT";
-   std::string COLLECT = "COLLECT";
    std::string COLLECT_SILENTLY = "COLLECT_SILENTLY";
    std::string IF_IN_INVENTORY = "IF_IN_INVENTORY";
    std::string ADD_FLAG = "ADD_FLAG";
@@ -238,6 +242,25 @@ bool ScriptRunner::parse_and_run_line(std::string raw_script_line, int line_num)
          emit_script_event(spawn_dialog_event_data);
          //Disabled:: created_dialog = dialog_factory.create_basic_dialog(std::vector<std::string>{script_line});
       }
+   }
+   else if (command == ENTER_ROOM)
+   {
+      std::cout << "processing ENTER_ROOM" << std::endl;
+      std::vector<std::string> tokens = tokenize(argument);
+      if (!assert_token_count_eq(tokens, 1))
+      {
+         std::cout << "ENTER_ROOM - expecting 1 and only 1 argument on line " << line_num << std::endl;
+         return false;
+      }
+      std::cout << "processing ENTER_ROOM BBB" << std::endl;
+
+      std::string room_name = tokens[0];
+      std::cout << "processing ENTER_ROOM CCC" << std::endl;
+
+      AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::EnterRoom *enter_room_event_datas =
+         new AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::EnterRoom(room_name);
+      emit_script_event(enter_room_event_datas);
+      std::cout << "processing ENTER_ROOM DDD" << std::endl;
    }
    else if (command == PLAY_MUSIC)
    {

--- a/src/AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner.cpp
+++ b/src/AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner.cpp
@@ -245,22 +245,18 @@ bool ScriptRunner::parse_and_run_line(std::string raw_script_line, int line_num)
    }
    else if (command == ENTER_ROOM)
    {
-      std::cout << "processing ENTER_ROOM" << std::endl;
       std::vector<std::string> tokens = tokenize(argument);
       if (!assert_token_count_eq(tokens, 1))
       {
          std::cout << "ENTER_ROOM - expecting 1 and only 1 argument on line " << line_num << std::endl;
          return false;
       }
-      std::cout << "processing ENTER_ROOM BBB" << std::endl;
 
       std::string room_name = tokens[0];
-      std::cout << "processing ENTER_ROOM CCC" << std::endl;
 
       AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::EnterRoom *enter_room_event_datas =
          new AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::EnterRoom(room_name);
       emit_script_event(enter_room_event_datas);
-      std::cout << "processing ENTER_ROOM DDD" << std::endl;
    }
    else if (command == PLAY_MUSIC)
    {

--- a/tests/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelperTest.cpp
+++ b/tests/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelperTest.cpp
@@ -48,6 +48,19 @@ TEST(AllegroFlare_Prototypes_FixedRoom2D_EntityCollectionHelperTest,
 
 
 TEST(AllegroFlare_Prototypes_FixedRoom2D_EntityCollectionHelperTest,
+   find_entity_by_dictionary_name__if_the_listing_does_not_exist_with_that_name__will_return_nullptr)
+{
+   std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> entity_dictionary;
+   AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper entity_collection_helper(&entity_dictionary);
+
+   AllegroFlare::Prototypes::FixedRoom2D::Entities::Base *found_entity =
+      entity_collection_helper.find_entity_by_dictionary_name("something_that_does_not_exist");
+
+   EXPECT_EQ(nullptr, found_entity);
+}
+
+
+TEST(AllegroFlare_Prototypes_FixedRoom2D_EntityCollectionHelperTest,
    find_entity_by_dictionary_name__will_return_the_entity_listed_under_the_name)
 {
    AllegroFlare::Prototypes::FixedRoom2D::Entities::Base gameboy;
@@ -68,6 +81,85 @@ TEST(AllegroFlare_Prototypes_FixedRoom2D_EntityCollectionHelperTest,
       entity_collection_helper.find_entity_by_dictionary_name("ball_of_yarn");
 
    EXPECT_EQ(&ball_of_yarn, found_entity);
+}
+
+
+TEST(AllegroFlare_Prototypes_FixedRoom2D_EntityCollectionHelperTest,
+   get_entities_by_entity_names__will_return_entities_matching_names)
+{
+   AllegroFlare::Prototypes::FixedRoom2D::Entities::Base gameboy;
+   AllegroFlare::Prototypes::FixedRoom2D::Entities::Base ball_of_yarn;
+   AllegroFlare::Prototypes::FixedRoom2D::Entities::Base chair;
+   AllegroFlare::Prototypes::FixedRoom2D::Entities::Base persian_rug;
+
+   std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> entity_dictionary = {
+      { "gameboy",       &gameboy },
+      { "ball_of_yarn",  &ball_of_yarn },
+      { "chair",         &chair },
+      { "persian_rug",   &persian_rug },
+   };
+
+   AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper entity_collection_helper(&entity_dictionary);
+
+   std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> returned_entities =
+      entity_collection_helper.get_entities_by_entity_names({"ball_of_yarn", "persian_rug"});
+
+   std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> expected_entities = {
+      &ball_of_yarn, &persian_rug,
+   };
+
+   ASSERT_THAT(returned_entities,
+      ::testing::UnorderedElementsAreArray(expected_entities.begin(), expected_entities.end()));
+}
+
+
+TEST(AllegroFlare_Prototypes_FixedRoom2D_EntityCollectionHelperTest,
+   get_entities_by_entity_names__if_a_listing_does_not_exist_with_a_provided_name__will_output_an_error_message)
+{
+   AllegroFlare::Prototypes::FixedRoom2D::Entities::Base gameboy;
+   AllegroFlare::Prototypes::FixedRoom2D::Entities::Base ball_of_yarn;
+   AllegroFlare::Prototypes::FixedRoom2D::Entities::Base chair;
+   AllegroFlare::Prototypes::FixedRoom2D::Entities::Base persian_rug;
+
+   std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> entity_dictionary = {
+      { "gameboy",       &gameboy },
+      { "ball_of_yarn",  &ball_of_yarn },
+      { "chair",         &chair },
+      { "persian_rug",   &persian_rug },
+   };
+
+   AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper entity_collection_helper(&entity_dictionary);
+
+   testing::internal::CaptureStdout();
+
+   entity_collection_helper.get_entities_by_entity_names({"ball_of_yarn", "entity-name-that-does-not-exist", "chair"});
+
+   std::string expected_cout_output = "[FixedRoom2D::EntityCollectionHelper::get_entities_from_entity_names]: warning: "
+                                      "The provided entity name \"entity-name-that-does-not-exist\" does not have a "
+                                      "listing. Ignoring.\n";
+   std::string actual_cout_output = testing::internal::GetCapturedStdout();
+   EXPECT_EQ(expected_cout_output, actual_cout_output);
+}
+
+
+TEST(AllegroFlare_Prototypes_FixedRoom2D_EntityCollectionHelperTest,
+   order_by_id__will_return_the_entities_ordered_by_id)
+{
+   AllegroFlare::Prototypes::FixedRoom2D::Entities::Base entity_1; // note that entities are automatically assigned an
+   AllegroFlare::Prototypes::FixedRoom2D::Entities::Base entity_2;        // id on creation because they derive from
+   AllegroFlare::Prototypes::FixedRoom2D::Entities::Base entity_3;        // AllegroFlare::ElementID. Each id will
+   AllegroFlare::Prototypes::FixedRoom2D::Entities::Base entity_4;        // be sequential in order of creation
+   AllegroFlare::Prototypes::FixedRoom2D::Entities::Base entity_5;
+   AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper entity_collection_helper;
+
+   std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> actual_entities =
+      entity_collection_helper.order_by_id( { &entity_5, &entity_2, &entity_3, &entity_1, &entity_4 } );
+
+   std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> expected_ordered_entities = {
+      &entity_1, &entity_2, &entity_3, &entity_4, &entity_5,
+   };
+
+   EXPECT_EQ(expected_ordered_entities, actual_entities);
 }
 
 

--- a/tests/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelperTest.cpp
+++ b/tests/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelperTest.cpp
@@ -1,5 +1,6 @@
 
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelper.hpp>
 
@@ -7,6 +8,42 @@
 TEST(AllegroFlare_Prototypes_FixedRoom2D_EntityCollectionHelperTest, can_be_created_without_blowing_up)
 {
    AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper entity_collection_helper;
+}
+
+
+TEST(AllegroFlare_Prototypes_FixedRoom2D_EntityCollectionHelperTest,
+   select_all_entity_names_in_room_name__will_return_all_entity_names_that_are_currently_associated_with_the_room_name)
+{
+   std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> entity_dictionary = {
+      { "gameboy",       nullptr },
+      { "ball_of_yarn",  nullptr },
+      { "chair",         nullptr },
+      { "persian_rug",   nullptr },
+      { "garden_gnome",  nullptr },
+      { "headphones",    nullptr },
+      { "record_player", nullptr },
+      { "vinyl_record",  nullptr },
+   };
+   std::map<std::string, std::string> entity_room_associations = {
+      { "gameboy",       "playroom" },
+      { "ball_of_yarn",  "terrace" },
+      { "chair",         "terrace" },
+      { "persian_rug",   "terrace" },
+      { "garden_gnome",  "front_porch" },
+      { "headphones",    "playroom" },
+      { "record_player", "playroom"},
+      { "vinyl_record",  "playroom" },
+   };
+   
+   AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper entity_collection_helper(
+      &entity_dictionary, &entity_room_associations);
+
+   std::vector<std::string> expected_entity_names = { "ball_of_yarn", "chair", "persian_rug" };
+   std::vector<std::string> actual_entity_names =
+      entity_collection_helper.select_all_entity_names_in_room_name("terrace");
+
+   ASSERT_THAT(actual_entity_names,
+      ::testing::UnorderedElementsAreArray(expected_entity_names.begin(), expected_entity_names.end()));
 }
 
 

--- a/tests/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelperTest.cpp
+++ b/tests/AllegroFlare/Prototypes/FixedRoom2D/EntityCollectionHelperTest.cpp
@@ -47,3 +47,27 @@ TEST(AllegroFlare_Prototypes_FixedRoom2D_EntityCollectionHelperTest,
 }
 
 
+TEST(AllegroFlare_Prototypes_FixedRoom2D_EntityCollectionHelperTest,
+   find_entity_by_dictionary_name__will_return_the_entity_listed_under_the_name)
+{
+   AllegroFlare::Prototypes::FixedRoom2D::Entities::Base gameboy;
+   AllegroFlare::Prototypes::FixedRoom2D::Entities::Base ball_of_yarn;
+   AllegroFlare::Prototypes::FixedRoom2D::Entities::Base chair;
+   AllegroFlare::Prototypes::FixedRoom2D::Entities::Base persian_rug;
+
+   std::map<std::string, AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> entity_dictionary = {
+      { "gameboy",       &gameboy },
+      { "ball_of_yarn",  &ball_of_yarn },
+      { "chair",         &chair },
+      { "persian_rug",   &persian_rug },
+   };
+
+   AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper entity_collection_helper(&entity_dictionary);
+
+   AllegroFlare::Prototypes::FixedRoom2D::Entities::Base *found_entity =
+      entity_collection_helper.find_entity_by_dictionary_name("ball_of_yarn");
+
+   EXPECT_EQ(&ball_of_yarn, found_entity);
+}
+
+

--- a/tests/AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/EnterRoomTest.cpp
+++ b/tests/AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/EnterRoomTest.cpp
@@ -1,0 +1,18 @@
+
+#include <gtest/gtest.h>
+
+#include <AllegroFlare/Prototypes/FixedRoom2D/ScriptEventDatas/EnterRoom.hpp>
+
+
+TEST(AllegroFlare_Prototypes_FixedRoom2D_ScriptEventDatas_EnterRoomTest, can_be_created_without_blowing_up)
+{
+   AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::EnterRoom enter_room;
+}
+
+
+TEST(AllegroFlare_Prototypes_FixedRoom2D_ScriptEventDatas_EnterRoomTest, run__returns_the_expected_response)
+{
+   AllegroFlare::Prototypes::FixedRoom2D::ScriptEventDatas::EnterRoom enter_room;
+   EXPECT_EQ("EnterRoom", enter_room.get_type());
+}
+


### PR DESCRIPTION
## Problem

Some changes in `master` caused some sloppy code design to infect itself all the way up to a bugs in gameplay, and in some cases a crash when running `Prototype/FixedRoom2D`.  These sections still remain mostly untested which could be a result of the prototype still finding it design/shape.

## Solution

The code was beat into submission with a few design constraints:

- A `Room` should not contain the `Entities/*` (ie. should not hold a `entities` property), nor should a `Room` know its name as is listed in the `room_dictionary`.
- `Entities/*` should not know the rooms they are in (ie. should not have a `currently_in_room` property).
- `Prototype/FixedRoom2D` now holds a `entities_room_association` which is a map containing the associations between entities and the rooms they are currently in.

At this point, some sloppy-code artifacts still remain, but the constraints are in place and the rest of the design/objects conform to it and the gameplay bugs are gone.

Sloppy code artifacts include:

- Some cross-talk (as in mixed or shared responsibility) between `FixedRoom2D/Room` and `FixedRoom2D/FixedRoom2D` that will need to be clarified.  I'm concerned `FixedRoom2D/Room` will be coded into thin air and the responsibility will ultimately end up being passed into `FixedRoom2D/FixedRoom2D`.  `Room` never quite had a clear role in the architecture.
- `Cursor` is currently held in `Room`.  All cursors are being reset to default any time a room is entered.  It seems like there should probably only be one cursor in `FixedRoom2D/FixedRoom2D` rather than one in each room.
- Getting and managing entities and rooms is a bit of a bungle.  Switching between `name` properties and pointers to the classes themselves is a bit clumsy.  Mostly, managing this responsibility has moved to the `FixedRoom2D/EntityCollectionHelper`, which now holds a pointer to the new associations map.  It's likely that this collection-helper could be expanded and new sub-tables (similar to SQL indexes) could be introduced to better manage and maintain all the sets and combinations so there isn't constant data processing all the time.
- There even appears to be lack of confidence when retrieving elements (`if (element_retrieved_is_valid && ...` is appearing more in the code) indicating that there is a better possibility for management of the entities, rooms, and associations.  Not having a good design here could be a bigger risk when scripting is involved.