### PR TITLE
Merge changes during TINS22 into master

### DIFF
--- a/documentation/dependents.json
+++ b/documentation/dependents.json
@@ -282,6 +282,7 @@
     "AllegroFlare/Screens/PauseScreen",
     "AllegroFlare/Screens/Storyboard",
     "AllegroFlare/Screens/TitleScreen",
+    "AllegroFlare/Testing/WithAllegroRenderingFixture",
     "AllegroFlare/UnicodeFontViewer",
     "AllegroFlare/Useful3D/Triangle"
   ],

--- a/documentation/dependents.json
+++ b/documentation/dependents.json
@@ -717,6 +717,9 @@
   "AllegroFlare/Prototypes/FixedRoom2D/ConfigurationFactory": [
     "AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D"
   ],
+  "AllegroFlare/Shader": [
+    "AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D"
+  ],
   "AllegroFlare/Prototypes/FixedRoom2D/RoomDictionary": [
     "AllegroFlare/Prototypes/FixedRoom2D/Room",
     "AllegroFlare/Prototypes/FixedRoom2D/Screen"

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -4375,6 +4375,18 @@ table td
     </table>
      <table>
 <tr>
+  <td class="method">set_bitmap_bin(1)</td>
+</tr>
+<tr>
+  <td class="method">set_font_bin(1)</td>
+</tr>
+<tr>
+  <td class="method">set_event_emitter(1)</td>
+</tr>
+<tr>
+  <td class="method">set_audio_controller(1)</td>
+</tr>
+<tr>
   <td class="method">initialize()</td>
 </tr>
 <tr>

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -3912,6 +3912,10 @@ table td
   <td class="property">AllegroFlare::Prototypes::FixedRoom2D::Room*</td>
 </tr>
 <tr>
+  <td class="property">room_shader</td>
+  <td class="property">AllegroFlare::Shader*</td>
+</tr>
+<tr>
   <td class="property">initialized</td>
   <td class="property">bool</td>
 </tr>
@@ -4128,6 +4132,9 @@ table td
 </tr>
 <tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::Prototypes::FixedRoom2D::Configuration&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/Prototypes/FixedRoom2D/Configuration.hpp&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::Shader*&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/Shader.hpp&quot;]}</td>
 </tr>
     </table>
   </div>
@@ -6644,6 +6651,9 @@ table td
     "AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D"
   ],
   "AllegroFlare/Prototypes/FixedRoom2D/ConfigurationFactory": [
+    "AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D"
+  ],
+  "AllegroFlare/Shader": [
     "AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D"
   ],
   "AllegroFlare/Prototypes/FixedRoom2D/RoomDictionary": [

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -5189,6 +5189,10 @@ table td
   <td class="property">ALLEGRO_COLOR</td>
 </tr>
 <tr>
+  <td class="property">menu_selected_text_color</td>
+  <td class="property">ALLEGRO_COLOR</td>
+</tr>
+<tr>
   <td class="property">copyright_text_color</td>
   <td class="property">ALLEGRO_COLOR</td>
 </tr>

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -3655,6 +3655,9 @@ table td
   <td class="method">move(2)</td>
 </tr>
 <tr>
+  <td class="method">move_to(2)</td>
+</tr>
+<tr>
   <td class="method">clear_info_text()</td>
 </tr>
 <tr>
@@ -5482,6 +5485,9 @@ table td
   <td class="method">draw_rulers()</td>
 </tr>
 <tr>
+  <td class="method">draw_crosshair(4)</td>
+</tr>
+<tr>
   <td class="method">test_name_indicates_it_wants_a_screenshot()</td>
 </tr>
 <tr>
@@ -5512,6 +5518,9 @@ table td
 </tr>
 <tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;ALLEGRO_FONT*&quot;, &quot;headers&quot;=&gt;[&quot;allegro5/allegro_font.h&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;ALLEGRO_COLOR&quot;, &quot;headers&quot;=&gt;[&quot;allegro5/allegro.h&quot;]}</td>
 </tr>
 <tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;al_color_name&quot;, &quot;headers&quot;=&gt;[&quot;allegro5/allegro_color.h&quot;]}</td>
@@ -6234,6 +6243,7 @@ table td
     "AllegroFlare/Screens/PauseScreen",
     "AllegroFlare/Screens/Storyboard",
     "AllegroFlare/Screens/TitleScreen",
+    "AllegroFlare/Testing/WithAllegroRenderingFixture",
     "AllegroFlare/UnicodeFontViewer",
     "AllegroFlare/Useful3D/Triangle"
   ],

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -3734,6 +3734,10 @@ table td
   <td class="property">show_hover_as_hue_change</td>
   <td class="property">bool</td>
 </tr>
+<tr>
+  <td class="property">hidden</td>
+  <td class="property">bool</td>
+</tr>
     </table>
      <table>
 <tr>

--- a/include/AllegroFlare/Prototypes/FixedRoom2D/Cursor.hpp
+++ b/include/AllegroFlare/Prototypes/FixedRoom2D/Cursor.hpp
@@ -41,6 +41,7 @@ namespace AllegroFlare
             void draw();
             void update();
             void move(float distance_x=0.0f, float distance_y=0.0f);
+            void move_to(float x=0.0f, float y=0.0f);
             void clear_info_text();
             void set_cursor_to_pointer();
             void set_cursor_to_grab();

--- a/include/AllegroFlare/Prototypes/FixedRoom2D/Entities/Base.hpp
+++ b/include/AllegroFlare/Prototypes/FixedRoom2D/Entities/Base.hpp
@@ -26,6 +26,7 @@ namespace AllegroFlare
                float cursor_exited_at;
                bool cursor_insights_are_hidden;
                bool show_hover_as_hue_change;
+               bool hidden;
 
             public:
                Base(ALLEGRO_BITMAP* bitmap=nullptr, AllegroFlare::Placement2D placement={}, std::string on_cursor_interact_script_name="[unset-on_cursor_interact_script_name]");
@@ -36,6 +37,7 @@ namespace AllegroFlare
                void set_on_cursor_interact_script_name(std::string on_cursor_interact_script_name);
                void set_cursor_insights_are_hidden(bool cursor_insights_are_hidden);
                void set_show_hover_as_hue_change(bool show_hover_as_hue_change);
+               void set_hidden(bool hidden);
                ALLEGRO_BITMAP* get_bitmap();
                AllegroFlare::Placement2D get_placement();
                std::string get_on_cursor_interact_script_name();
@@ -44,6 +46,7 @@ namespace AllegroFlare
                float get_cursor_exited_at();
                bool get_cursor_insights_are_hidden();
                bool get_show_hover_as_hue_change();
+               bool get_hidden();
                AllegroFlare::Placement2D &get_placement_ref();
                virtual void render();
                virtual void update();

--- a/include/AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D.hpp
+++ b/include/AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D.hpp
@@ -17,6 +17,7 @@
 #include <AllegroFlare/Prototypes/FixedRoom2D/Room.hpp>
 #include <AllegroFlare/Prototypes/FixedRoom2D/Script.hpp>
 #include <AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner.hpp>
+#include <AllegroFlare/Shader.hpp>
 #include <map>
 #include <set>
 #include <string>
@@ -47,6 +48,7 @@ namespace AllegroFlare
             AllegroFlare::Prototypes::FixedRoom2D::ScriptRunner script_runner;
             AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper entity_collection_helper;
             AllegroFlare::Prototypes::FixedRoom2D::Room* current_room;
+            AllegroFlare::Shader* room_shader;
             bool initialized;
             AllegroFlare::Elements::DialogBoxes::Base* active_dialog;
             bool paused;
@@ -59,6 +61,8 @@ namespace AllegroFlare
             void set_bitmap_bin(AllegroFlare::BitmapBin* bitmap_bin);
             void set_event_emitter(AllegroFlare::EventEmitter* event_emitter);
             void set_audio_controller(AllegroFlare::AudioController* audio_controller);
+            void set_room_shader(AllegroFlare::Shader* room_shader);
+            AllegroFlare::Shader* get_room_shader();
             AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper &get_entity_collection_helper_ref();
             void set_font_bin(AllegroFlare::FontBin* font_bin=nullptr);
             std::set<std::string> get_subscribed_to_game_event_names();

--- a/include/AllegroFlare/Prototypes/FixedRoom2D/RoomFactory.hpp
+++ b/include/AllegroFlare/Prototypes/FixedRoom2D/RoomFactory.hpp
@@ -26,6 +26,14 @@ namespace AllegroFlare
             RoomFactory(AllegroFlare::BitmapBin* bitmap_bin=nullptr, AllegroFlare::FontBin* font_bin=nullptr, AllegroFlare::EventEmitter* event_emitter=nullptr, AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper* entity_collection_helper=nullptr);
             ~RoomFactory();
 
+            void set_bitmap_bin(AllegroFlare::BitmapBin* bitmap_bin);
+            void set_font_bin(AllegroFlare::FontBin* font_bin);
+            void set_event_emitter(AllegroFlare::EventEmitter* event_emitter);
+            void set_entity_collection_helper(AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper* entity_collection_helper);
+            AllegroFlare::BitmapBin* get_bitmap_bin();
+            AllegroFlare::FontBin* get_font_bin();
+            AllegroFlare::EventEmitter* get_event_emitter();
+            AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper* get_entity_collection_helper();
             AllegroFlare::Prototypes::FixedRoom2D::Room* create_room(float width=(1920-200), float height=(1080-200));
          };
       }

--- a/include/AllegroFlare/Prototypes/FixedRoom2D/Screen.hpp
+++ b/include/AllegroFlare/Prototypes/FixedRoom2D/Screen.hpp
@@ -33,6 +33,10 @@ namespace AllegroFlare
             virtual ~Screen();
 
             AllegroFlare::Prototypes::FixedRoom2D::FixedRoom2D &get_fixed_room_2d_ref();
+            void set_bitmap_bin(AllegroFlare::BitmapBin* bitmap_bin=nullptr);
+            void set_font_bin(AllegroFlare::FontBin* font_bin=nullptr);
+            void set_event_emitter(AllegroFlare::EventEmitter* event_emitter=nullptr);
+            void set_audio_controller(AllegroFlare::AudioController* audio_controller=nullptr);
             void initialize();
             void load_gametest_configuration_and_start();
             void load_game_configuration_and_start(AllegroFlare::Prototypes::FixedRoom2D::Configuration configuration={});

--- a/include/AllegroFlare/Screens/TitleScreen.hpp
+++ b/include/AllegroFlare/Screens/TitleScreen.hpp
@@ -30,6 +30,7 @@ namespace AllegroFlare
          ALLEGRO_COLOR title_text_color;
          ALLEGRO_COLOR menu_text_color;
          ALLEGRO_COLOR menu_selector_color;
+         ALLEGRO_COLOR menu_selected_text_color;
          ALLEGRO_COLOR copyright_text_color;
          int title_font_size;
          int menu_font_size;
@@ -40,7 +41,7 @@ namespace AllegroFlare
          int cursor_position;
 
       public:
-         TitleScreen(AllegroFlare::EventEmitter* event_emitter=nullptr, AllegroFlare::FontBin* font_bin=nullptr, AllegroFlare::BitmapBin* bitmap_bin=nullptr, std::string title_text="Untitled Game", std::string copyright_text="Copyright 2022", std::string background_bitmap_name="", std::string title_bitmap_name="", std::string font_name="Inter-Medium.ttf", ALLEGRO_COLOR title_text_color=ALLEGRO_COLOR{1, 1, 1, 1}, ALLEGRO_COLOR menu_text_color=ALLEGRO_COLOR{1, 1, 1, 1}, ALLEGRO_COLOR menu_selector_color=ALLEGRO_COLOR{1, 1, 1, 1}, ALLEGRO_COLOR copyright_text_color=ALLEGRO_COLOR{1, 1, 1, 1}, int title_font_size=-90, int menu_font_size=-48, int copyright_font_size=-32);
+         TitleScreen(AllegroFlare::EventEmitter* event_emitter=nullptr, AllegroFlare::FontBin* font_bin=nullptr, AllegroFlare::BitmapBin* bitmap_bin=nullptr, std::string title_text="Untitled Game", std::string copyright_text="Copyright 2022", std::string background_bitmap_name="", std::string title_bitmap_name="", std::string font_name="Inter-Medium.ttf", ALLEGRO_COLOR title_text_color=ALLEGRO_COLOR{1, 1, 1, 1}, ALLEGRO_COLOR menu_text_color=ALLEGRO_COLOR{1, 1, 1, 1}, ALLEGRO_COLOR menu_selector_color=ALLEGRO_COLOR{1, 1, 1, 1}, ALLEGRO_COLOR menu_selected_text_color=ALLEGRO_COLOR{0, 0, 0, 1}, ALLEGRO_COLOR copyright_text_color=ALLEGRO_COLOR{1, 1, 1, 1}, int title_font_size=-90, int menu_font_size=-48, int copyright_font_size=-32);
          virtual ~TitleScreen();
 
          void set_event_emitter(AllegroFlare::EventEmitter* event_emitter);
@@ -54,6 +55,7 @@ namespace AllegroFlare
          void set_title_text_color(ALLEGRO_COLOR title_text_color);
          void set_menu_text_color(ALLEGRO_COLOR menu_text_color);
          void set_menu_selector_color(ALLEGRO_COLOR menu_selector_color);
+         void set_menu_selected_text_color(ALLEGRO_COLOR menu_selected_text_color);
          void set_copyright_text_color(ALLEGRO_COLOR copyright_text_color);
          void set_title_font_size(int title_font_size);
          void set_menu_font_size(int menu_font_size);
@@ -68,6 +70,7 @@ namespace AllegroFlare
          ALLEGRO_COLOR get_title_text_color();
          ALLEGRO_COLOR get_menu_text_color();
          ALLEGRO_COLOR get_menu_selector_color();
+         ALLEGRO_COLOR get_menu_selected_text_color();
          ALLEGRO_COLOR get_copyright_text_color();
          int get_title_font_size();
          int get_menu_font_size();

--- a/include/AllegroFlare/Shader.hpp
+++ b/include/AllegroFlare/Shader.hpp
@@ -22,7 +22,7 @@ namespace AllegroFlare
 
    public:
       Shader(std::string vertex_source_code="", std::string fragment_source_code="");
-      ~Shader();
+      virtual ~Shader();
 
       // initialize
       void initialize();
@@ -42,8 +42,8 @@ namespace AllegroFlare
       static bool set_vec4(const char *name, float x, float y, float z, float a);
 
       // activate and deactivate
-      void activate();
-      void deactivate();
+      virtual void activate();
+      virtual void deactivate();
    };
 }
 

--- a/include/AllegroFlare/Testing/WithAllegroRenderingFixture.hpp
+++ b/include/AllegroFlare/Testing/WithAllegroRenderingFixture.hpp
@@ -38,6 +38,7 @@ namespace AllegroFlare
          std::string build_full_test_name_str();
          AllegroFlare::Placement2D build_centered_placement(float width=0.0f, float height=0.0f);
          void draw_rulers();
+         void draw_crosshair(float x=0.0f, float y=0.0f, ALLEGRO_COLOR color=ALLEGRO_COLOR{1, 0, 0, 1}, float size=200.0f);
          bool test_name_indicates_it_wants_a_screenshot();
          void clear_display();
          void capture_screenshot(std::string base_filename="WithAllegroRenderingFixture-screenshot.png");

--- a/quintessence/AllegroFlare/Prototypes/FixedRoom2D/Cursor.q.yml
+++ b/quintessence/AllegroFlare/Prototypes/FixedRoom2D/Cursor.q.yml
@@ -21,7 +21,7 @@ properties:
 
   - name: icon_offset_placement
     type: AllegroFlare::Placement2D
-    init_with: '{}'
+    init_with: '-9, -2, 0, 0'
 
   - name: info_text_offset_placement
     type: AllegroFlare::Placement2D
@@ -87,6 +87,20 @@ functions:
       return;
 
 
+  - name: move_to
+    parameters:
+      - name: x
+        type: float
+        default_argument: 0.0f
+      - name: y
+        type: float
+        default_argument: 0.0f
+    body: |
+      this->x = x;
+      this->y = y;
+      return;
+
+
   - name: clear_info_text
     body: |
       cursor_last_set_at = 0;
@@ -98,6 +112,7 @@ functions:
     body: |
       cursor_last_set_at = 0;
       icon_character_num = 62042;
+      icon_offset_placement = Placement2D(-9, -2, 0, 0);
       return;
       
 
@@ -105,6 +120,7 @@ functions:
     body: |
       cursor_last_set_at = 0;
       icon_character_num = 62038;
+      icon_offset_placement = Placement2D(-16, -4, 0, 0);
       return;
       
 

--- a/quintessence/AllegroFlare/Prototypes/FixedRoom2D/Entities/Base.q.yml
+++ b/quintessence/AllegroFlare/Prototypes/FixedRoom2D/Entities/Base.q.yml
@@ -58,6 +58,12 @@ properties:
     getter: true
     setter: true
 
+  - name: hidden
+    type: bool
+    init_with: false
+    getter: true
+    setter: true
+
 
 functions:
 
@@ -65,7 +71,7 @@ functions:
   - name: render
     virtual: true
     body: |
-      if (!bitmap) return;
+      if (!bitmap || get_hidden()) return;
 
       placement.start_transform();
 

--- a/quintessence/AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D.q.yml
+++ b/quintessence/AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D.q.yml
@@ -69,6 +69,12 @@ properties:
     type: AllegroFlare::Prototypes::FixedRoom2D::Room*
     init_with: nullptr
 
+  - name: room_shader
+    type: AllegroFlare::Shader*
+    init_with: nullptr
+    getter: true
+    setter: true
+
   - name: initialized
     type: bool
     init_with: false
@@ -318,7 +324,10 @@ functions:
       // render the current room
       if (current_room)
       {
+         if (room_shader) room_shader->activate();
          render_entities_in_current_room();
+         if (room_shader) room_shader->deactivate();
+
          current_room->render(); // for now, only renders the cursor
       }
       else
@@ -782,5 +791,7 @@ dependencies:
     headers: [ AllegroFlare/Prototypes/FixedRoom2D/ConfigurationFactory.hpp ]
   - symbol: AllegroFlare::Prototypes::FixedRoom2D::Configuration
     headers: [ AllegroFlare/Prototypes/FixedRoom2D/Configuration.hpp ]
+  - symbol: AllegroFlare::Shader*
+    headers: [ AllegroFlare/Shader.hpp ]
 
   

--- a/quintessence/AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D.q.yml
+++ b/quintessence/AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D.q.yml
@@ -511,6 +511,7 @@ functions:
       std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> entities = get_entities_in_current_room();
       for (auto &entity : entities)
       {
+         // NOTE: some entities are set to "hidden=-true" and they will not actually render if called to
          if (entity) entity->render();
       }
       return;

--- a/quintessence/AllegroFlare/Prototypes/FixedRoom2D/Room.q.yml
+++ b/quintessence/AllegroFlare/Prototypes/FixedRoom2D/Room.q.yml
@@ -158,7 +158,7 @@ functions:
       for (auto &entity : entities_in_this_room)
       {
          if (entity->get_cursor_is_over()) entity_cursor_was_over = entity;
-         if (entity->get_placement_ref().collide(cursor_x, cursor_y)) entity_cursor_is_now_over = entity;
+         if (entity->get_placement_ref().collide_as_if(entity->get_bitmap(), cursor_x, cursor_y)) entity_cursor_is_now_over = entity;
       }
 
       // a change has happened

--- a/quintessence/AllegroFlare/Prototypes/FixedRoom2D/RoomFactory.q.yml
+++ b/quintessence/AllegroFlare/Prototypes/FixedRoom2D/RoomFactory.q.yml
@@ -5,21 +5,29 @@ properties:
     type: AllegroFlare::BitmapBin*
     init_with: nullptr
     constructor_arg: true
+    getter: true
+    setter: true
 
   - name: font_bin
     type: AllegroFlare::FontBin*
     init_with: nullptr
     constructor_arg: true
+    getter: true
+    setter: true
 
   - name: event_emitter
     type: AllegroFlare::EventEmitter*
     init_with: nullptr
     constructor_arg: true
+    getter: true
+    setter: true
 
   - name: entity_collection_helper
     type: AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper*
     init_with: nullptr
     constructor_arg: true
+    getter: true
+    setter: true
 
 
 functions:

--- a/quintessence/AllegroFlare/Prototypes/FixedRoom2D/Screen.q.yml
+++ b/quintessence/AllegroFlare/Prototypes/FixedRoom2D/Screen.q.yml
@@ -13,21 +13,25 @@ properties:
     type: AllegroFlare::BitmapBin*
     init_with: nullptr
     constructor_arg: true
+    setter: false
 
   - name: font_bin
     type: AllegroFlare::FontBin*
     init_with: nullptr
     constructor_arg: true
+    setter: false
 
   - name: event_emitter
     type: AllegroFlare::EventEmitter*
     init_with: nullptr
     constructor_arg: true
+    setter: false
 
   - name: audio_controller
     type: AllegroFlare::AudioController*
     init_with: nullptr
     constructor_arg: true
+    setter: false
 
   - name: fixed_room_2d
     type: AllegroFlare::Prototypes::FixedRoom2D::FixedRoom2D
@@ -40,6 +44,50 @@ properties:
 
 
 functions:
+
+
+  - name: set_bitmap_bin
+    parameters:
+      - name: bitmap_bin
+        type: AllegroFlare::BitmapBin*
+        default_argument: nullptr
+    body: |
+      this->bitmap_bin = bitmap_bin;
+      fixed_room_2d.set_bitmap_bin(bitmap_bin);
+      return;
+
+
+  - name: set_font_bin
+    parameters:
+      - name: font_bin
+        type: AllegroFlare::FontBin*
+        default_argument: nullptr
+    body: |
+      this->font_bin = font_bin;
+      fixed_room_2d.set_font_bin(font_bin);
+      return;
+
+
+  - name: set_event_emitter
+    parameters:
+      - name: event_emitter
+        type: AllegroFlare::EventEmitter*
+        default_argument: nullptr
+    body: |
+      this->event_emitter = event_emitter;
+      fixed_room_2d.set_event_emitter(event_emitter);
+      return;
+
+
+  - name: set_audio_controller
+    parameters:
+      - name: audio_controller
+        type: AllegroFlare::AudioController*
+        default_argument: nullptr
+    body: |
+      this->audio_controller = audio_controller;
+      fixed_room_2d.set_audio_controller(audio_controller);
+      return;
 
 
   - name: initialize

--- a/quintessence/AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner.q.yml
+++ b/quintessence/AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner.q.yml
@@ -291,7 +291,8 @@ functions:
       }
       else
       {
-         std::cout << "WARNING: Unrecognized command \"" << command << "\"" << std::endl;
+         std::cout << "[AllegroFlare::Prototypes::FixedRoom2D::ScriptRunner::parse_and_run_line]: WARNING: "
+                   << "Unrecognized command \"" << command << "\"" << std::endl;
          continue_directly_to_next_script_line = true;
       }
 

--- a/quintessence/AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner.q.yml
+++ b/quintessence/AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner.q.yml
@@ -156,6 +156,7 @@ functions:
       std::string COLLECT = "COLLECT";
       std::string OPEN_SCRIPT = "OPEN_SCRIPT";
       std::string PLAY_SOUND_EFFECT = "PLAY_SOUND_EFFECT";
+      std::string PLAY_MUSIC_TRACK = "PLAY_MUSIC_TRACK";
 
       bool continue_directly_to_next_script_line = false;
 
@@ -263,13 +264,28 @@ functions:
          std::vector<std::string> tokens = tokenize(argument);
          if (!assert_token_count_eq(tokens, 1))
          {
-            std::cout << "ENTER_ROOM - expecting 1 and only 1 argument on line " << line_num << std::endl;
+            std::cout << "PLAY_SOUND_EFFECT - expecting 1 and only 1 argument on line " << line_num << std::endl;
             return false;
          }
 
          std::string sound_effect_name_to_play = tokens[0];
 
          event_emitter->emit_play_sound_effect_event(sound_effect_name_to_play);
+
+         continue_directly_to_next_script_line = true;
+      }
+      else if (command == PLAY_MUSIC_TRACK)
+      {
+         std::vector<std::string> tokens = tokenize(argument);
+         if (!assert_token_count_eq(tokens, 1))
+         {
+            std::cout << "PLAY_MUSIC_TRACK - expecting 1 and only 1 argument on line " << line_num << std::endl;
+            return false;
+         }
+
+         std::string music_track_name_to_play = tokens[0];
+
+         event_emitter->emit_play_music_track_event(music_track_name_to_play);
 
          continue_directly_to_next_script_line = true;
       }

--- a/quintessence/AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner.q.yml
+++ b/quintessence/AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner.q.yml
@@ -155,6 +155,7 @@ functions:
       std::string SIGNAL = "SIGNAL"; // outputs text to the terminal
       std::string COLLECT = "COLLECT";
       std::string OPEN_SCRIPT = "OPEN_SCRIPT";
+      std::string PLAY_SOUND_EFFECT = "PLAY_SOUND_EFFECT";
 
       bool continue_directly_to_next_script_line = false;
 
@@ -255,6 +256,21 @@ functions:
                       << "but that marker does not exist. This is from line ["
                       << line_num << "], which is \"" << script_line << "\"" << std::endl;
          }
+         continue_directly_to_next_script_line = true;
+      }
+      else if (command == PLAY_SOUND_EFFECT)
+      {
+         std::vector<std::string> tokens = tokenize(argument);
+         if (!assert_token_count_eq(tokens, 1))
+         {
+            std::cout << "ENTER_ROOM - expecting 1 and only 1 argument on line " << line_num << std::endl;
+            return false;
+         }
+
+         std::string sound_effect_name_to_play = tokens[0];
+
+         event_emitter->emit_play_sound_effect_event(sound_effect_name_to_play);
+
          continue_directly_to_next_script_line = true;
       }
       else

--- a/quintessence/AllegroFlare/Screens/TitleScreen.q.yml
+++ b/quintessence/AllegroFlare/Screens/TitleScreen.q.yml
@@ -83,6 +83,13 @@ properties:
     getter: true
     setter: true
 
+  - name: menu_selected_text_color
+    type: ALLEGRO_COLOR
+    init_with: ALLEGRO_COLOR{0, 0, 0, 1}
+    constructor_arg: true
+    getter: true
+    setter: true
+
   - name: copyright_text_color
     type: ALLEGRO_COLOR
     init_with: ALLEGRO_COLOR{1, 1, 1, 1}
@@ -350,7 +357,7 @@ functions:
          std::string menu_item_text = std::get<0>(menu_option);
 
          ALLEGRO_COLOR this_menu_text_color = showing_cursor_on_this_option
-            ? ALLEGRO_COLOR{0, 0, 0, 1.0} : menu_text_color;
+            ? menu_selected_text_color : menu_text_color;
 
          float x = menu_position_x;
          float y = menu_position_y + menu_item_vertical_spacing * menu_item_num;

--- a/quintessence/AllegroFlare/Screens/TitleScreen.q.yml
+++ b/quintessence/AllegroFlare/Screens/TitleScreen.q.yml
@@ -361,7 +361,7 @@ functions:
             float box_height = al_get_font_line_height(menu_font) + 6;
             float h_box_width = box_width * 0.5;
             float h_box_height = box_height * 0.5;
-            al_draw_filled_rectangle(x-h_box_width, y-h_box_height, x+h_box_width, y+h_box_height, menu_text_color);
+            al_draw_filled_rectangle(x-h_box_width, y-h_box_height, x+h_box_width, y+h_box_height, menu_selector_color);
          }
 
          al_draw_text(

--- a/quintessence/AllegroFlare/Testing/WithAllegroRenderingFixture.q.yml
+++ b/quintessence/AllegroFlare/Testing/WithAllegroRenderingFixture.q.yml
@@ -168,6 +168,31 @@ functions:
       - al_color_name
 
 
+  - name: draw_crosshair
+    guards: [ al_get_target_bitmap() ]
+    parameters:
+      - name: x
+        type: float
+        default_argument: 0.0f
+      - name: y
+        type: float
+        default_argument: 0.0f
+      - name: color
+        type: ALLEGRO_COLOR
+        default_argument: ALLEGRO_COLOR{1, 0, 0, 1}
+      - name: size
+        type: float
+        default_argument: 200.0f
+    body: |
+      float h_size = size * 0.5;
+      // draw horizontal line
+      al_draw_line(x-h_size, y, x+h_size, y, color, 1.0);
+      // draw vertical line
+      al_draw_line(x, y-h_size, x, y+h_size, color, 1.0);
+    body_dependency_symbols:
+      - al_color_name
+
+
   - name: test_name_indicates_it_wants_a_screenshot
     type: bool
     body: |
@@ -179,6 +204,8 @@ functions:
       ALLEGRO_COLOR eigengrau = ALLEGRO_COLOR{0.086f, 0.086f, 0.114f, 1.0f};
       al_clear_to_color(eigengrau);
       return;
+    body_dependency_symbols:
+      - ALLEGRO_COLOR
 
 
   - name: capture_screenshot
@@ -228,6 +255,8 @@ dependencies:
     headers: [ allegro5/allegro.h ]
   - symbol: ALLEGRO_FONT*
     headers: [ allegro5/allegro_font.h ]
+  - symbol: ALLEGRO_COLOR
+    headers: [ allegro5/allegro.h ]
   - symbol: al_color_name
     headers: [ allegro5/allegro_color.h ]
   - symbol: AllegroFlare::FontBin

--- a/src/AllegroFlare/Prototypes/FixedRoom2D/Cursor.cpp
+++ b/src/AllegroFlare/Prototypes/FixedRoom2D/Cursor.cpp
@@ -21,7 +21,7 @@ Cursor::Cursor(AllegroFlare::FontBin* font_bin)
    : font_bin(font_bin)
    , x(1920/2)
    , y(1080/2)
-   , icon_offset_placement({})
+   , icon_offset_placement(-9, -2, 0, 0)
    , info_text_offset_placement(40, 0, 0, 0)
    , info_text("[unset-info_text]")
    , info_text_flags(0)
@@ -114,6 +114,13 @@ void Cursor::move(float distance_x, float distance_y)
    return;
 }
 
+void Cursor::move_to(float x, float y)
+{
+   this->x = x;
+   this->y = y;
+   return;
+}
+
 void Cursor::clear_info_text()
 {
    cursor_last_set_at = 0;
@@ -125,6 +132,7 @@ void Cursor::set_cursor_to_pointer()
 {
    cursor_last_set_at = 0;
    icon_character_num = 62042;
+   icon_offset_placement = Placement2D(-9, -2, 0, 0);
    return;
 }
 
@@ -132,6 +140,7 @@ void Cursor::set_cursor_to_grab()
 {
    cursor_last_set_at = 0;
    icon_character_num = 62038;
+   icon_offset_placement = Placement2D(-16, -4, 0, 0);
    return;
 }
 

--- a/src/AllegroFlare/Prototypes/FixedRoom2D/Entities/Base.cpp
+++ b/src/AllegroFlare/Prototypes/FixedRoom2D/Entities/Base.cpp
@@ -24,6 +24,7 @@ Base::Base(ALLEGRO_BITMAP* bitmap, AllegroFlare::Placement2D placement, std::str
    , cursor_exited_at(0.0f)
    , cursor_insights_are_hidden(false)
    , show_hover_as_hue_change(false)
+   , hidden(false)
 {
 }
 
@@ -60,6 +61,12 @@ void Base::set_cursor_insights_are_hidden(bool cursor_insights_are_hidden)
 void Base::set_show_hover_as_hue_change(bool show_hover_as_hue_change)
 {
    this->show_hover_as_hue_change = show_hover_as_hue_change;
+}
+
+
+void Base::set_hidden(bool hidden)
+{
+   this->hidden = hidden;
 }
 
 
@@ -111,6 +118,12 @@ bool Base::get_show_hover_as_hue_change()
 }
 
 
+bool Base::get_hidden()
+{
+   return hidden;
+}
+
+
 AllegroFlare::Placement2D &Base::get_placement_ref()
 {
    return placement;
@@ -119,7 +132,7 @@ AllegroFlare::Placement2D &Base::get_placement_ref()
 
 void Base::render()
 {
-   if (!bitmap) return;
+   if (!bitmap || get_hidden()) return;
 
    placement.start_transform();
 

--- a/src/AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D.cpp
+++ b/src/AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D.cpp
@@ -93,6 +93,7 @@ FixedRoom2D::FixedRoom2D(AllegroFlare::BitmapBin* bitmap_bin, AllegroFlare::Font
    , script_runner({})
    , entity_collection_helper({})
    , current_room(nullptr)
+   , room_shader(nullptr)
    , initialized(false)
    , active_dialog(nullptr)
    , paused(false)
@@ -121,6 +122,18 @@ void FixedRoom2D::set_event_emitter(AllegroFlare::EventEmitter* event_emitter)
 void FixedRoom2D::set_audio_controller(AllegroFlare::AudioController* audio_controller)
 {
    this->audio_controller = audio_controller;
+}
+
+
+void FixedRoom2D::set_room_shader(AllegroFlare::Shader* room_shader)
+{
+   this->room_shader = room_shader;
+}
+
+
+AllegroFlare::Shader* FixedRoom2D::get_room_shader()
+{
+   return room_shader;
 }
 
 
@@ -389,7 +402,10 @@ void FixedRoom2D::render()
    // render the current room
    if (current_room)
    {
+      if (room_shader) room_shader->activate();
       render_entities_in_current_room();
+      if (room_shader) room_shader->deactivate();
+
       current_room->render(); // for now, only renders the cursor
    }
    else

--- a/src/AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D.cpp
+++ b/src/AllegroFlare/Prototypes/FixedRoom2D/FixedRoom2D.cpp
@@ -575,6 +575,7 @@ void FixedRoom2D::render_entities_in_current_room()
    std::vector<AllegroFlare::Prototypes::FixedRoom2D::Entities::Base*> entities = get_entities_in_current_room();
    for (auto &entity : entities)
    {
+      // NOTE: some entities are set to "hidden=-true" and they will not actually render if called to
       if (entity) entity->render();
    }
    return;

--- a/src/AllegroFlare/Prototypes/FixedRoom2D/Room.cpp
+++ b/src/AllegroFlare/Prototypes/FixedRoom2D/Room.cpp
@@ -233,7 +233,7 @@ void Room::move_cursor(float distance_x, float distance_y, std::vector<AllegroFl
    for (auto &entity : entities_in_this_room)
    {
       if (entity->get_cursor_is_over()) entity_cursor_was_over = entity;
-      if (entity->get_placement_ref().collide(cursor_x, cursor_y)) entity_cursor_is_now_over = entity;
+      if (entity->get_placement_ref().collide_as_if(entity->get_bitmap(), cursor_x, cursor_y)) entity_cursor_is_now_over = entity;
    }
 
    // a change has happened

--- a/src/AllegroFlare/Prototypes/FixedRoom2D/RoomFactory.cpp
+++ b/src/AllegroFlare/Prototypes/FixedRoom2D/RoomFactory.cpp
@@ -27,6 +27,54 @@ RoomFactory::~RoomFactory()
 }
 
 
+void RoomFactory::set_bitmap_bin(AllegroFlare::BitmapBin* bitmap_bin)
+{
+   this->bitmap_bin = bitmap_bin;
+}
+
+
+void RoomFactory::set_font_bin(AllegroFlare::FontBin* font_bin)
+{
+   this->font_bin = font_bin;
+}
+
+
+void RoomFactory::set_event_emitter(AllegroFlare::EventEmitter* event_emitter)
+{
+   this->event_emitter = event_emitter;
+}
+
+
+void RoomFactory::set_entity_collection_helper(AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper* entity_collection_helper)
+{
+   this->entity_collection_helper = entity_collection_helper;
+}
+
+
+AllegroFlare::BitmapBin* RoomFactory::get_bitmap_bin()
+{
+   return bitmap_bin;
+}
+
+
+AllegroFlare::FontBin* RoomFactory::get_font_bin()
+{
+   return font_bin;
+}
+
+
+AllegroFlare::EventEmitter* RoomFactory::get_event_emitter()
+{
+   return event_emitter;
+}
+
+
+AllegroFlare::Prototypes::FixedRoom2D::EntityCollectionHelper* RoomFactory::get_entity_collection_helper()
+{
+   return entity_collection_helper;
+}
+
+
 AllegroFlare::Prototypes::FixedRoom2D::Room* RoomFactory::create_room(float width, float height)
 {
    if (!(bitmap_bin))

--- a/src/AllegroFlare/Prototypes/FixedRoom2D/Screen.cpp
+++ b/src/AllegroFlare/Prototypes/FixedRoom2D/Screen.cpp
@@ -50,6 +50,34 @@ AllegroFlare::Prototypes::FixedRoom2D::FixedRoom2D &Screen::get_fixed_room_2d_re
 }
 
 
+void Screen::set_bitmap_bin(AllegroFlare::BitmapBin* bitmap_bin)
+{
+   this->bitmap_bin = bitmap_bin;
+   fixed_room_2d.set_bitmap_bin(bitmap_bin);
+   return;
+}
+
+void Screen::set_font_bin(AllegroFlare::FontBin* font_bin)
+{
+   this->font_bin = font_bin;
+   fixed_room_2d.set_font_bin(font_bin);
+   return;
+}
+
+void Screen::set_event_emitter(AllegroFlare::EventEmitter* event_emitter)
+{
+   this->event_emitter = event_emitter;
+   fixed_room_2d.set_event_emitter(event_emitter);
+   return;
+}
+
+void Screen::set_audio_controller(AllegroFlare::AudioController* audio_controller)
+{
+   this->audio_controller = audio_controller;
+   fixed_room_2d.set_audio_controller(audio_controller);
+   return;
+}
+
 void Screen::initialize()
 {
    if (!((!initialized)))

--- a/src/AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner.cpp
+++ b/src/AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner.cpp
@@ -220,6 +220,7 @@ bool ScriptRunner::parse_and_run_line(std::string raw_script_line, int line_num,
    std::string SIGNAL = "SIGNAL"; // outputs text to the terminal
    std::string COLLECT = "COLLECT";
    std::string OPEN_SCRIPT = "OPEN_SCRIPT";
+   std::string PLAY_SOUND_EFFECT = "PLAY_SOUND_EFFECT";
 
    bool continue_directly_to_next_script_line = false;
 
@@ -320,6 +321,21 @@ bool ScriptRunner::parse_and_run_line(std::string raw_script_line, int line_num,
                    << "but that marker does not exist. This is from line ["
                    << line_num << "], which is \"" << script_line << "\"" << std::endl;
       }
+      continue_directly_to_next_script_line = true;
+   }
+   else if (command == PLAY_SOUND_EFFECT)
+   {
+      std::vector<std::string> tokens = tokenize(argument);
+      if (!assert_token_count_eq(tokens, 1))
+      {
+         std::cout << "ENTER_ROOM - expecting 1 and only 1 argument on line " << line_num << std::endl;
+         return false;
+      }
+
+      std::string sound_effect_name_to_play = tokens[0];
+
+      event_emitter->emit_play_sound_effect_event(sound_effect_name_to_play);
+
       continue_directly_to_next_script_line = true;
    }
    else

--- a/src/AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner.cpp
+++ b/src/AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner.cpp
@@ -221,6 +221,7 @@ bool ScriptRunner::parse_and_run_line(std::string raw_script_line, int line_num,
    std::string COLLECT = "COLLECT";
    std::string OPEN_SCRIPT = "OPEN_SCRIPT";
    std::string PLAY_SOUND_EFFECT = "PLAY_SOUND_EFFECT";
+   std::string PLAY_MUSIC_TRACK = "PLAY_MUSIC_TRACK";
 
    bool continue_directly_to_next_script_line = false;
 
@@ -328,13 +329,28 @@ bool ScriptRunner::parse_and_run_line(std::string raw_script_line, int line_num,
       std::vector<std::string> tokens = tokenize(argument);
       if (!assert_token_count_eq(tokens, 1))
       {
-         std::cout << "ENTER_ROOM - expecting 1 and only 1 argument on line " << line_num << std::endl;
+         std::cout << "PLAY_SOUND_EFFECT - expecting 1 and only 1 argument on line " << line_num << std::endl;
          return false;
       }
 
       std::string sound_effect_name_to_play = tokens[0];
 
       event_emitter->emit_play_sound_effect_event(sound_effect_name_to_play);
+
+      continue_directly_to_next_script_line = true;
+   }
+   else if (command == PLAY_MUSIC_TRACK)
+   {
+      std::vector<std::string> tokens = tokenize(argument);
+      if (!assert_token_count_eq(tokens, 1))
+      {
+         std::cout << "PLAY_MUSIC_TRACK - expecting 1 and only 1 argument on line " << line_num << std::endl;
+         return false;
+      }
+
+      std::string music_track_name_to_play = tokens[0];
+
+      event_emitter->emit_play_music_track_event(music_track_name_to_play);
 
       continue_directly_to_next_script_line = true;
    }

--- a/src/AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner.cpp
+++ b/src/AllegroFlare/Prototypes/FixedRoom2D/ScriptRunner.cpp
@@ -356,7 +356,8 @@ bool ScriptRunner::parse_and_run_line(std::string raw_script_line, int line_num,
    }
    else
    {
-      std::cout << "WARNING: Unrecognized command \"" << command << "\"" << std::endl;
+      std::cout << "[AllegroFlare::Prototypes::FixedRoom2D::ScriptRunner::parse_and_run_line]: WARNING: "
+                << "Unrecognized command \"" << command << "\"" << std::endl;
       continue_directly_to_next_script_line = true;
    }
 

--- a/src/AllegroFlare/Screens/TitleScreen.cpp
+++ b/src/AllegroFlare/Screens/TitleScreen.cpp
@@ -30,7 +30,7 @@ namespace Screens
 {
 
 
-TitleScreen::TitleScreen(AllegroFlare::EventEmitter* event_emitter, AllegroFlare::FontBin* font_bin, AllegroFlare::BitmapBin* bitmap_bin, std::string title_text, std::string copyright_text, std::string background_bitmap_name, std::string title_bitmap_name, std::string font_name, ALLEGRO_COLOR title_text_color, ALLEGRO_COLOR menu_text_color, ALLEGRO_COLOR menu_selector_color, ALLEGRO_COLOR copyright_text_color, int title_font_size, int menu_font_size, int copyright_font_size)
+TitleScreen::TitleScreen(AllegroFlare::EventEmitter* event_emitter, AllegroFlare::FontBin* font_bin, AllegroFlare::BitmapBin* bitmap_bin, std::string title_text, std::string copyright_text, std::string background_bitmap_name, std::string title_bitmap_name, std::string font_name, ALLEGRO_COLOR title_text_color, ALLEGRO_COLOR menu_text_color, ALLEGRO_COLOR menu_selector_color, ALLEGRO_COLOR menu_selected_text_color, ALLEGRO_COLOR copyright_text_color, int title_font_size, int menu_font_size, int copyright_font_size)
    : AllegroFlare::Screens::Base("TitleScreen")
    , event_emitter(event_emitter)
    , font_bin(font_bin)
@@ -43,6 +43,7 @@ TitleScreen::TitleScreen(AllegroFlare::EventEmitter* event_emitter, AllegroFlare
    , title_text_color(title_text_color)
    , menu_text_color(menu_text_color)
    , menu_selector_color(menu_selector_color)
+   , menu_selected_text_color(menu_selected_text_color)
    , copyright_text_color(copyright_text_color)
    , title_font_size(title_font_size)
    , menu_font_size(menu_font_size)
@@ -123,6 +124,12 @@ void TitleScreen::set_menu_text_color(ALLEGRO_COLOR menu_text_color)
 void TitleScreen::set_menu_selector_color(ALLEGRO_COLOR menu_selector_color)
 {
    this->menu_selector_color = menu_selector_color;
+}
+
+
+void TitleScreen::set_menu_selected_text_color(ALLEGRO_COLOR menu_selected_text_color)
+{
+   this->menu_selected_text_color = menu_selected_text_color;
 }
 
 
@@ -207,6 +214,12 @@ ALLEGRO_COLOR TitleScreen::get_menu_text_color()
 ALLEGRO_COLOR TitleScreen::get_menu_selector_color()
 {
    return menu_selector_color;
+}
+
+
+ALLEGRO_COLOR TitleScreen::get_menu_selected_text_color()
+{
+   return menu_selected_text_color;
 }
 
 
@@ -478,7 +491,7 @@ void TitleScreen::draw_menu()
       std::string menu_item_text = std::get<0>(menu_option);
 
       ALLEGRO_COLOR this_menu_text_color = showing_cursor_on_this_option
-         ? ALLEGRO_COLOR{0, 0, 0, 1.0} : menu_text_color;
+         ? menu_selected_text_color : menu_text_color;
 
       float x = menu_position_x;
       float y = menu_position_y + menu_item_vertical_spacing * menu_item_num;

--- a/src/AllegroFlare/Screens/TitleScreen.cpp
+++ b/src/AllegroFlare/Screens/TitleScreen.cpp
@@ -489,7 +489,7 @@ void TitleScreen::draw_menu()
          float box_height = al_get_font_line_height(menu_font) + 6;
          float h_box_width = box_width * 0.5;
          float h_box_height = box_height * 0.5;
-         al_draw_filled_rectangle(x-h_box_width, y-h_box_height, x+h_box_width, y+h_box_height, menu_text_color);
+         al_draw_filled_rectangle(x-h_box_width, y-h_box_height, x+h_box_width, y+h_box_height, menu_selector_color);
       }
 
       al_draw_text(

--- a/src/AllegroFlare/Testing/WithAllegroRenderingFixture.cpp
+++ b/src/AllegroFlare/Testing/WithAllegroRenderingFixture.cpp
@@ -14,6 +14,10 @@
 #include <allegro5/allegro_color.h>
 #include <stdexcept>
 #include <sstream>
+#include <allegro5/allegro_color.h>
+#include <stdexcept>
+#include <sstream>
+#include <allegro5/allegro.h>
 #include <chrono>
 #include <thread>
 
@@ -167,6 +171,21 @@ void WithAllegroRenderingFixture::draw_rulers()
       }
    al_draw_line(1920/2, 0, 1920/2, 1080, al_color_name("gray"), 1.0); // rulers down the center
    al_draw_line(0, 1080/2, 1920, 1080/2, al_color_name("gray"), 1.0); // rulers across the middle
+}
+
+void WithAllegroRenderingFixture::draw_crosshair(float x, float y, ALLEGRO_COLOR color, float size)
+{
+   if (!(al_get_target_bitmap()))
+      {
+         std::stringstream error_message;
+         error_message << "WithAllegroRenderingFixture" << "::" << "draw_crosshair" << ": error: " << "guard \"al_get_target_bitmap()\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   float h_size = size * 0.5;
+   // draw horizontal line
+   al_draw_line(x-h_size, y, x+h_size, y, color, 1.0);
+   // draw vertical line
+   al_draw_line(x, y-h_size, x, y+h_size, color, 1.0);
 }
 
 bool WithAllegroRenderingFixture::test_name_indicates_it_wants_a_screenshot()

--- a/tests/AllegroFlare/Prototypes/FixedRoom2D/CursorTest.cpp
+++ b/tests/AllegroFlare/Prototypes/FixedRoom2D/CursorTest.cpp
@@ -1,12 +1,44 @@
 
 #include <gtest/gtest.h>
 
+#define ASSERT_THROW_WITH_MESSAGE(code, raised_exception_type, expected_exception_message) \
+   try { code; FAIL() << "Expected " # raised_exception_type; } \
+   catch ( raised_exception_type const &err ) { ASSERT_EQ(std::string(expected_exception_message), err.what()); } \
+   catch (...) { FAIL() << "Expected " # raised_exception_type; }
+
+#include <AllegroFlare/Testing/WithAllegroRenderingFixture.hpp>
+
+
+class AllegroFlare_Prototypes_FixedRoom2D_CursorTest : public ::testing::Test
+{};
+
+class AllegroFlare_Prototypes_FixedRoom2D_CursorTestWithAllegroRenderingFixture
+   : public AllegroFlare::Testing::WithAllegroRenderingFixture
+{};
+
+
 #include <AllegroFlare/Prototypes/FixedRoom2D/Cursor.hpp>
 
 
-TEST(AllegroFlare_Prototypes_FixedRoom2D_CursorTest, can_be_created_without_blowing_up)
+TEST_F(AllegroFlare_Prototypes_FixedRoom2D_CursorTest, can_be_created_without_blowing_up)
 {
    AllegroFlare::Prototypes::FixedRoom2D::Cursor cursor;
 }
 
+
+TEST_F(AllegroFlare_Prototypes_FixedRoom2D_CursorTest, draw__without_a_font_bin__raises_an_error)
+{
+   AllegroFlare::Prototypes::FixedRoom2D::Cursor cursor;
+   std::string expected_error_message =
+      "Cursor::draw: error: guard \"font_bin\" not met";
+   ASSERT_THROW_WITH_MESSAGE(cursor.draw(), std::runtime_error, expected_error_message);
+}
+
+
+TEST_F(AllegroFlare_Prototypes_FixedRoom2D_CursorTestWithAllegroRenderingFixture, draw__will_not_blow_up)
+{
+   AllegroFlare::Prototypes::FixedRoom2D::Cursor cursor(&get_font_bin_ref());
+   cursor.draw();
+   SUCCEED();
+}
 

--- a/tests/AllegroFlare/Prototypes/FixedRoom2D/CursorTest.cpp
+++ b/tests/AllegroFlare/Prototypes/FixedRoom2D/CursorTest.cpp
@@ -8,6 +8,8 @@
 
 #include <AllegroFlare/Testing/WithAllegroRenderingFixture.hpp>
 
+#include <allegro5/allegro_primitives.h>
+
 
 class AllegroFlare_Prototypes_FixedRoom2D_CursorTest : public ::testing::Test
 {};
@@ -41,4 +43,26 @@ TEST_F(AllegroFlare_Prototypes_FixedRoom2D_CursorTestWithAllegroRenderingFixture
    cursor.draw();
    SUCCEED();
 }
+
+
+TEST_F(AllegroFlare_Prototypes_FixedRoom2D_CursorTestWithAllegroRenderingFixture,
+   CAPTURE__draw__will_have_a_properly_offset_pointer_icon_that_points_to_the_cursor_x_y)
+{
+   AllegroFlare::Prototypes::FixedRoom2D::Cursor cursor(&get_font_bin_ref());
+   cursor.clear_info_text();
+
+   cursor.draw();
+   draw_crosshair(cursor.get_x(), cursor.get_y());
+
+   cursor.move(200, 100);
+
+   cursor.set_cursor_to_grab();
+   cursor.draw();
+   draw_crosshair(cursor.get_x(), cursor.get_y());
+
+   al_flip_display();
+   sleep(1);
+   SUCCEED();
+}
+
 

--- a/tests/AllegroFlare/Prototypes/FixedRoom2D/ScriptRunnerTest.cpp
+++ b/tests/AllegroFlare/Prototypes/FixedRoom2D/ScriptRunnerTest.cpp
@@ -195,6 +195,14 @@ TEST(AllegroFlare_Prototypes_FixedRoom2D_ScriptRunnerTest,
 
 
 TEST(AllegroFlare_Prototypes_FixedRoom2D_ScriptRunnerTest,
+   parse_and_run_line__will_parse_a_PLAY_MUSIC_TRACK_command_and_emit_an_ALLEGRO_FLARE_PLAY_MUSIC_TRACK_event)
+   // note this is a private method test
+{
+   // TODO
+}
+
+
+TEST(AllegroFlare_Prototypes_FixedRoom2D_ScriptRunnerTest,
    play_or_resume__command_and_argument__will_trim_the_argument_fragment)
 {
    // note this is a private method test

--- a/tests/AllegroFlare/Prototypes/FixedRoom2D/ScriptRunnerTest.cpp
+++ b/tests/AllegroFlare/Prototypes/FixedRoom2D/ScriptRunnerTest.cpp
@@ -187,6 +187,14 @@ TEST(AllegroFlare_Prototypes_FixedRoom2D_ScriptRunnerTest,
 
 
 TEST(AllegroFlare_Prototypes_FixedRoom2D_ScriptRunnerTest,
+   parse_and_run_line__will_parse_a_PLAY_SOUND_EFFECT_command_and_emit_an_ALLEGRO_FLARE_PLAY_SOUND_EFFECT_event)
+   // note this is a private method test
+{
+   // TODO
+}
+
+
+TEST(AllegroFlare_Prototypes_FixedRoom2D_ScriptRunnerTest,
    play_or_resume__command_and_argument__will_trim_the_argument_fragment)
 {
    // note this is a private method test


### PR DESCRIPTION
## The following changes were made to `master` during TINS 2022

master (before TINS): ac7f3dc1d7af080b11ad75b30fbab14d264ae420
tins22 branch: 2dcefa20629ce359a0b7129bd1e6d9b217fe29c1

diff: https://github.com/allegroflare/allegro_flare/compare/ac7f3dc1d7af080b11ad75b30fbab14d264ae420...2dcefa20629ce359a0b7129bd1e6d9b217fe29c1

## Major Differences

- `FixedRoom2D/Entities/Base` now have "hidden" property

- `FixedRoom2D/Cursor` now has "move_to" and adjusted "icon_offset_placement" for the different icon types

- `Shader` will now work with other derived shaders (virtual destructor, virtual activate/deactivate, maybe should consider "preactivate" to set internally assumed variables).

- `Testing/WithAllegroRenderingFixture` now has "draw_crosshair" function. Could consider adding a "draw_grid" would be nice.

- Can now set `FixedRoom2D/RoomFactory` dependencies post-class instanciation.

- `FixedRoom2D/Room` now uses "collide_as_if"

- `FixedRoom2D/ScriptRunner` now has "PLAY_SOUND_EFFECT" and "PLAY_MUSIC_TRACK"

- `TitleScreen` now uses "menu_selected_text_color", "menu_selector_color"



## Questionable Changes

- in `FixedRoom2D/FixedRoom2D`, hidden objects still have their "render()" called.
- `FixedRoom2D/FixedRoom2D` now has a "room_shader" that is activated before a room is rendered.
- The illusive `get_entity_collection_helper` dependency has made its way a little deeper, and should be extracted.