### PR TITLE
Add MultiMesh

### DIFF
--- a/documentation/dependents.json
+++ b/documentation/dependents.json
@@ -852,9 +852,6 @@
   "char": [
     "AllegroFlare/Network2/Message"
   ],
-  "char[16 + 512]": [
-    "AllegroFlare/Network2/Message"
-  ],
   "AllegroFlare/EncoderDecoders/Base62": [
     "AllegroFlare/Network2/Message"
   ],

--- a/documentation/dependents.json
+++ b/documentation/dependents.json
@@ -230,6 +230,7 @@
     "AllegroFlare/Elements/Backgrounds/ParallaxLayer",
     "AllegroFlare/Elements/StoryboardPages/Image",
     "AllegroFlare/MotionFX/Sparkles2",
+    "AllegroFlare/MultiMesh",
     "AllegroFlare/Prototypes/FixedRoom2D/Entities/Base",
     "AllegroFlare/Screens/PauseScreen",
     "AllegroFlare/Screens/TitleScreen",

--- a/documentation/dependents.json
+++ b/documentation/dependents.json
@@ -833,6 +833,9 @@
   "ALLEGRO_INDEX_BUFFER": [
     "AllegroFlare/MultiMesh"
   ],
+  "AllegroFlare/MultiMeshUVAtlas": [
+    "AllegroFlare/MultiMesh"
+  ],
   "std/map<int, AllegroFlare/MultiMeshUV>": [
     "AllegroFlare/MultiMeshUVAtlas"
   ],

--- a/documentation/dependents.json
+++ b/documentation/dependents.json
@@ -832,6 +832,12 @@
   "ALLEGRO_INDEX_BUFFER": [
     "AllegroFlare/MultiMesh"
   ],
+  "std/map<int, AllegroFlare/MultiMeshUV>": [
+    "AllegroFlare/MultiMeshUVAtlas"
+  ],
+  "AllegroFlare/MultiMeshUV": [
+    "AllegroFlare/MultiMeshUVAtlas"
+  ],
   "chat_message": [
     "AllegroFlare/Network2/Message"
   ],

--- a/documentation/dependents.json
+++ b/documentation/dependents.json
@@ -825,6 +825,12 @@
     "AllegroFlare/MotionFX/Sparkles2",
     "AllegroFlare/Timeline/ActorFactory"
   ],
+  "ALLEGRO_VERTEX_BUFFER": [
+    "AllegroFlare/MultiMesh"
+  ],
+  "ALLEGRO_INDEX_BUFFER": [
+    "AllegroFlare/MultiMesh"
+  ],
   "chat_message": [
     "AllegroFlare/Network2/Message"
   ],

--- a/documentation/dependents.json
+++ b/documentation/dependents.json
@@ -827,6 +827,9 @@
     "AllegroFlare/MotionFX/Sparkles2",
     "AllegroFlare/Timeline/ActorFactory"
   ],
+  "ALLEGRO_VERTEX_DECL": [
+    "AllegroFlare/MultiMesh"
+  ],
   "ALLEGRO_VERTEX_BUFFER": [
     "AllegroFlare/MultiMesh"
   ],

--- a/documentation/dependents.json
+++ b/documentation/dependents.json
@@ -674,6 +674,7 @@
   ],
   "std/size_t": [
     "AllegroFlare/EncoderDecoders/Base62",
+    "AllegroFlare/MultiMesh",
     "AllegroFlare/Network2/Message"
   ],
   "ALLEGRO_FLARE_EVENT_POST_ACHIEVEMENT_UNLOCKED_NOTIFICATION": [

--- a/documentation/dependents.json
+++ b/documentation/dependents.json
@@ -231,6 +231,7 @@
     "AllegroFlare/Elements/StoryboardPages/Image",
     "AllegroFlare/MotionFX/Sparkles2",
     "AllegroFlare/MultiMesh",
+    "AllegroFlare/MultiMeshUVAtlas",
     "AllegroFlare/Prototypes/FixedRoom2D/Entities/Base",
     "AllegroFlare/Screens/PauseScreen",
     "AllegroFlare/Screens/TitleScreen",

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -4803,7 +4803,7 @@ table td
      <table>
 <tr>
   <td class="property">num_items</td>
-  <td class="property">int</td>
+  <td class="property">std::size_t</td>
 </tr>
 <tr>
   <td class="property">vertex_buffer</td>
@@ -4872,6 +4872,9 @@ table td
 </tr>
 <tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::MultiMeshUVAtlas&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/MultiMeshUVAtlas.hpp&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;std::size_t&quot;, &quot;headers&quot;=&gt;[&quot;cstddef&quot;]}</td>
 </tr>
     </table>
   </div>
@@ -8606,6 +8609,7 @@ table td
   ],
   "std/size_t": [
     "AllegroFlare/EncoderDecoders/Base62",
+    "AllegroFlare/MultiMesh",
     "AllegroFlare/Network2/Message"
   ],
   "ALLEGRO_FLARE_EVENT_POST_ACHIEVEMENT_UNLOCKED_NOTIFICATION": [

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -4829,7 +4829,7 @@ table td
   <td class="method">initialize()</td>
 </tr>
 <tr>
-  <td class="method">append(4)</td>
+  <td class="method">append(8)</td>
 </tr>
 <tr>
   <td class="method">remove(1)</td>

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -4822,13 +4822,23 @@ table td
   <td class="property">int</td>
 </tr>
 <tr>
+  <td class="property">atlas</td>
+  <td class="property">AllegroFlare::MultiMeshUVAtlas</td>
+</tr>
+<tr>
   <td class="property">initialized</td>
   <td class="property">bool</td>
 </tr>
     </table>
      <table>
 <tr>
+  <td class="method">set_atlas(1)</td>
+</tr>
+<tr>
   <td class="method">initialize()</td>
+</tr>
+<tr>
+  <td class="method">append_item_from_atlas_index(3)</td>
 </tr>
 <tr>
   <td class="method">append(8)</td>
@@ -4849,6 +4859,9 @@ table td
 </tr>
 <tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;ALLEGRO_BITMAP*&quot;, &quot;headers&quot;=&gt;[&quot;allegro5/allegro.h&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::MultiMeshUVAtlas&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/MultiMeshUVAtlas.hpp&quot;]}</td>
 </tr>
     </table>
   </div>
@@ -4875,6 +4888,12 @@ table td
 </tr>
     </table>
      <table>
+<tr>
+  <td class="method">infer_width()</td>
+</tr>
+<tr>
+  <td class="method">infer_height()</td>
+</tr>
     </table>
      <table>
     </table>
@@ -4884,10 +4903,6 @@ table td
   <div class="component">
     <h3 id="quintessence/AllegroFlare/MultiMeshUVAtlas.q.yml">quintessence/AllegroFlare/MultiMeshUVAtlas.q.yml</h3>
      <table>
-<tr>
-  <td class="property">bitmap</td>
-  <td class="property">ALLEGRO_BITMAP*</td>
-</tr>
 <tr>
   <td class="property">index</td>
   <td class="property">std::map&lt;int, AllegroFlare::MultiMeshUV&gt;</td>
@@ -8738,6 +8753,9 @@ table td
     "AllegroFlare/MultiMesh"
   ],
   "ALLEGRO_INDEX_BUFFER": [
+    "AllegroFlare/MultiMesh"
+  ],
+  "AllegroFlare/MultiMeshUVAtlas": [
     "AllegroFlare/MultiMesh"
   ],
   "std/map<int, AllegroFlare/MultiMeshUV>": [

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -5028,9 +5028,6 @@ table td
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;char*&quot;, &quot;headers&quot;=&gt;[]}</td>
 </tr>
 <tr>
-  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;char[16 + 512]&quot;, &quot;headers&quot;=&gt;[]}</td>
-</tr>
-<tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;std::size_t&quot;, &quot;headers&quot;=&gt;[&quot;cstddef&quot;]}</td>
 </tr>
 <tr>
@@ -8785,9 +8782,6 @@ table td
     "AllegroFlare/Network2/Message"
   ],
   "char": [
-    "AllegroFlare/Network2/Message"
-  ],
-  "char[16 + 512]": [
     "AllegroFlare/Network2/Message"
   ],
   "AllegroFlare/EncoderDecoders/Base62": [

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -4802,16 +4802,20 @@ table td
     <h3 id="quintessence/AllegroFlare/MultiMesh.q.yml">quintessence/AllegroFlare/MultiMesh.q.yml</h3>
      <table>
 <tr>
+  <td class="property">num_items</td>
+  <td class="property">int</td>
+</tr>
+<tr>
   <td class="property">vertex_buffer</td>
   <td class="property">ALLEGRO_VERTEX_BUFFER*</td>
 </tr>
 <tr>
-  <td class="property">texture</td>
-  <td class="property">ALLEGRO_BITMAP*</td>
+  <td class="property">vertex_decl</td>
+  <td class="property">ALLEGRO_VERTEX_DECL*</td>
 </tr>
 <tr>
-  <td class="property">num_items</td>
-  <td class="property">int</td>
+  <td class="property">texture</td>
+  <td class="property">ALLEGRO_BITMAP*</td>
 </tr>
 <tr>
   <td class="property">vertices_in_use</td>
@@ -4835,6 +4839,9 @@ table td
   <td class="method">set_atlas(1)</td>
 </tr>
 <tr>
+  <td class="method">set_num_items(1)</td>
+</tr>
+<tr>
   <td class="method">initialize()</td>
 </tr>
 <tr>
@@ -4851,6 +4858,9 @@ table td
 </tr>
     </table>
      <table>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;ALLEGRO_VERTEX_DECL*&quot;, &quot;headers&quot;=&gt;[&quot;allegro5/allegro_primitives.h&quot;]}</td>
+</tr>
 <tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;ALLEGRO_VERTEX_BUFFER*&quot;, &quot;headers&quot;=&gt;[&quot;allegro5/allegro_primitives.h&quot;]}</td>
 </tr>
@@ -8748,6 +8758,9 @@ table td
   "AllegroFlare/Timeline/Actors/Actor2D": [
     "AllegroFlare/MotionFX/Sparkles2",
     "AllegroFlare/Timeline/ActorFactory"
+  ],
+  "ALLEGRO_VERTEX_DECL": [
+    "AllegroFlare/MultiMesh"
   ],
   "ALLEGRO_VERTEX_BUFFER": [
     "AllegroFlare/MultiMesh"

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -4804,10 +4804,6 @@ table td
   <td class="property">ALLEGRO_VERTEX_BUFFER*</td>
 </tr>
 <tr>
-  <td class="property">index_buffer</td>
-  <td class="property">ALLEGRO_INDEX_BUFFER*</td>
-</tr>
-<tr>
   <td class="property">texture</td>
   <td class="property">ALLEGRO_BITMAP*</td>
 </tr>

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -4816,6 +4816,10 @@ table td
   <td class="property">int</td>
 </tr>
 <tr>
+  <td class="property">VERTEXES_PER_ITEM</td>
+  <td class="property">int</td>
+</tr>
+<tr>
   <td class="property">initialized</td>
   <td class="property">bool</td>
 </tr>

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -4808,6 +4808,10 @@ table td
   <td class="property">ALLEGRO_INDEX_BUFFER*</td>
 </tr>
 <tr>
+  <td class="property">indexes_in_use</td>
+  <td class="property">int</td>
+</tr>
+<tr>
   <td class="property">initialized</td>
   <td class="property">bool</td>
 </tr>
@@ -4817,10 +4821,10 @@ table td
   <td class="method">initialize()</td>
 </tr>
 <tr>
-  <td class="method">append()</td>
+  <td class="method">append(4)</td>
 </tr>
 <tr>
-  <td class="method">remove()</td>
+  <td class="method">remove(1)</td>
 </tr>
 <tr>
   <td class="method">render()</td>

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -4808,7 +4808,7 @@ table td
   <td class="property">ALLEGRO_BITMAP*</td>
 </tr>
 <tr>
-  <td class="property">indexes_in_use</td>
+  <td class="property">vertices_in_use</td>
   <td class="property">int</td>
 </tr>
 <tr>

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -4838,10 +4838,10 @@ table td
   <td class="method">initialize()</td>
 </tr>
 <tr>
-  <td class="method">append_item_from_atlas_index(3)</td>
+  <td class="method">append(3)</td>
 </tr>
 <tr>
-  <td class="method">append(8)</td>
+  <td class="method">append_raw(8)</td>
 </tr>
 <tr>
   <td class="method">remove(1)</td>

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -4808,6 +4808,10 @@ table td
   <td class="property">ALLEGRO_BITMAP*</td>
 </tr>
 <tr>
+  <td class="property">num_items</td>
+  <td class="property">int</td>
+</tr>
+<tr>
   <td class="property">vertices_in_use</td>
   <td class="property">int</td>
 </tr>

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -4808,6 +4808,10 @@ table td
   <td class="property">ALLEGRO_INDEX_BUFFER*</td>
 </tr>
 <tr>
+  <td class="property">texture</td>
+  <td class="property">ALLEGRO_BITMAP*</td>
+</tr>
+<tr>
   <td class="property">indexes_in_use</td>
   <td class="property">int</td>
 </tr>
@@ -4836,6 +4840,9 @@ table td
 </tr>
 <tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;ALLEGRO_INDEX_BUFFER*&quot;, &quot;headers&quot;=&gt;[&quot;allegro5/allegro_primitives.h&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;ALLEGRO_BITMAP*&quot;, &quot;headers&quot;=&gt;[&quot;allegro5/allegro.h&quot;]}</td>
 </tr>
     </table>
   </div>
@@ -8060,6 +8067,7 @@ table td
     "AllegroFlare/Elements/Backgrounds/ParallaxLayer",
     "AllegroFlare/Elements/StoryboardPages/Image",
     "AllegroFlare/MotionFX/Sparkles2",
+    "AllegroFlare/MultiMesh",
     "AllegroFlare/Prototypes/FixedRoom2D/Entities/Base",
     "AllegroFlare/Screens/PauseScreen",
     "AllegroFlare/Screens/TitleScreen",

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -4885,6 +4885,10 @@ table td
     <h3 id="quintessence/AllegroFlare/MultiMeshUVAtlas.q.yml">quintessence/AllegroFlare/MultiMeshUVAtlas.q.yml</h3>
      <table>
 <tr>
+  <td class="property">bitmap</td>
+  <td class="property">ALLEGRO_BITMAP*</td>
+</tr>
+<tr>
   <td class="property">index</td>
   <td class="property">std::map&lt;int, AllegroFlare::MultiMeshUV&gt;</td>
 </tr>
@@ -4906,6 +4910,9 @@ table td
 </tr>
 <tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::MultiMeshUV&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/MultiMeshUV.hpp&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;ALLEGRO_BITMAP*&quot;, &quot;headers&quot;=&gt;[&quot;allegro5/allegro.h&quot;]}</td>
 </tr>
     </table>
   </div>
@@ -8131,6 +8138,7 @@ table td
     "AllegroFlare/Elements/StoryboardPages/Image",
     "AllegroFlare/MotionFX/Sparkles2",
     "AllegroFlare/MultiMesh",
+    "AllegroFlare/MultiMeshUVAtlas",
     "AllegroFlare/Prototypes/FixedRoom2D/Entities/Base",
     "AllegroFlare/Screens/PauseScreen",
     "AllegroFlare/Screens/TitleScreen",

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -126,6 +126,7 @@ table td
   <li><a href="#quintessence/AllegroFlare/MotionComposer/TrackView.q.yml">quintessence/AllegroFlare/MotionComposer/TrackView.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/MotionFX/Sparkles.q.yml">quintessence/AllegroFlare/MotionFX/Sparkles.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/MotionFX/Sparkles2.q.yml">quintessence/AllegroFlare/MotionFX/Sparkles2.q.yml</a></li>
+  <li><a href="#quintessence/AllegroFlare/MultiMesh.q.yml">quintessence/AllegroFlare/MultiMesh.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/Network2/Message.q.yml">quintessence/AllegroFlare/Network2/Message.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/Notifications.q.yml">quintessence/AllegroFlare/Notifications.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/NotificationsFactory.q.yml">quintessence/AllegroFlare/NotificationsFactory.q.yml</a></li>
@@ -4796,6 +4797,47 @@ table td
 </ul>
 <ul>
   <div class="component">
+    <h3 id="quintessence/AllegroFlare/MultiMesh.q.yml">quintessence/AllegroFlare/MultiMesh.q.yml</h3>
+     <table>
+<tr>
+  <td class="property">vertex_buffer</td>
+  <td class="property">ALLEGRO_VERTEX_BUFFER*</td>
+</tr>
+<tr>
+  <td class="property">index_buffer</td>
+  <td class="property">ALLEGRO_INDEX_BUFFER*</td>
+</tr>
+<tr>
+  <td class="property">initialized</td>
+  <td class="property">bool</td>
+</tr>
+    </table>
+     <table>
+<tr>
+  <td class="method">initialize()</td>
+</tr>
+<tr>
+  <td class="method">append()</td>
+</tr>
+<tr>
+  <td class="method">remove()</td>
+</tr>
+<tr>
+  <td class="method">render()</td>
+</tr>
+    </table>
+     <table>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;ALLEGRO_VERTEX_BUFFER*&quot;, &quot;headers&quot;=&gt;[&quot;allegro5/allegro_primitives.h&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;ALLEGRO_INDEX_BUFFER*&quot;, &quot;headers&quot;=&gt;[&quot;allegro5/allegro_primitives.h&quot;]}</td>
+</tr>
+    </table>
+  </div>
+</ul>
+<ul>
+  <div class="component">
     <h3 id="quintessence/AllegroFlare/Network2/Message.q.yml">quintessence/AllegroFlare/Network2/Message.q.yml</h3>
      <table>
 <tr>
@@ -8608,6 +8650,12 @@ table td
   "AllegroFlare/Timeline/Actors/Actor2D": [
     "AllegroFlare/MotionFX/Sparkles2",
     "AllegroFlare/Timeline/ActorFactory"
+  ],
+  "ALLEGRO_VERTEX_BUFFER": [
+    "AllegroFlare/MultiMesh"
+  ],
+  "ALLEGRO_INDEX_BUFFER": [
+    "AllegroFlare/MultiMesh"
   ],
   "chat_message": [
     "AllegroFlare/Network2/Message"

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -128,6 +128,7 @@ table td
   <li><a href="#quintessence/AllegroFlare/MotionFX/Sparkles2.q.yml">quintessence/AllegroFlare/MotionFX/Sparkles2.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/MultiMesh.q.yml">quintessence/AllegroFlare/MultiMesh.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/MultiMeshUV.q.yml">quintessence/AllegroFlare/MultiMeshUV.q.yml</a></li>
+  <li><a href="#quintessence/AllegroFlare/MultiMeshUVAtlas.q.yml">quintessence/AllegroFlare/MultiMeshUVAtlas.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/Network2/Message.q.yml">quintessence/AllegroFlare/Network2/Message.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/Notifications.q.yml">quintessence/AllegroFlare/Notifications.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/NotificationsFactory.q.yml">quintessence/AllegroFlare/NotificationsFactory.q.yml</a></li>
@@ -4881,6 +4882,36 @@ table td
 </ul>
 <ul>
   <div class="component">
+    <h3 id="quintessence/AllegroFlare/MultiMeshUVAtlas.q.yml">quintessence/AllegroFlare/MultiMeshUVAtlas.q.yml</h3>
+     <table>
+<tr>
+  <td class="property">index</td>
+  <td class="property">std::map&lt;int, AllegroFlare::MultiMeshUV&gt;</td>
+</tr>
+    </table>
+     <table>
+<tr>
+  <td class="method">add(5)</td>
+</tr>
+<tr>
+  <td class="method">exists(1)</td>
+</tr>
+<tr>
+  <td class="method">get(1)</td>
+</tr>
+    </table>
+     <table>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;std::map&lt;int, AllegroFlare::MultiMeshUV&gt;&quot;, &quot;headers&quot;=&gt;[&quot;map&quot;, &quot;AllegroFlare/MultiMeshUV.hpp&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::MultiMeshUV&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/MultiMeshUV.hpp&quot;]}</td>
+</tr>
+    </table>
+  </div>
+</ul>
+<ul>
+  <div class="component">
     <h3 id="quintessence/AllegroFlare/Network2/Message.q.yml">quintessence/AllegroFlare/Network2/Message.q.yml</h3>
      <table>
 <tr>
@@ -8700,6 +8731,12 @@ table td
   ],
   "ALLEGRO_INDEX_BUFFER": [
     "AllegroFlare/MultiMesh"
+  ],
+  "std/map<int, AllegroFlare/MultiMeshUV>": [
+    "AllegroFlare/MultiMeshUVAtlas"
+  ],
+  "AllegroFlare/MultiMeshUV": [
+    "AllegroFlare/MultiMeshUVAtlas"
   ],
   "chat_message": [
     "AllegroFlare/Network2/Message"

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -127,6 +127,7 @@ table td
   <li><a href="#quintessence/AllegroFlare/MotionFX/Sparkles.q.yml">quintessence/AllegroFlare/MotionFX/Sparkles.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/MotionFX/Sparkles2.q.yml">quintessence/AllegroFlare/MotionFX/Sparkles2.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/MultiMesh.q.yml">quintessence/AllegroFlare/MultiMesh.q.yml</a></li>
+  <li><a href="#quintessence/AllegroFlare/MultiMeshUV.q.yml">quintessence/AllegroFlare/MultiMeshUV.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/Network2/Message.q.yml">quintessence/AllegroFlare/Network2/Message.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/Notifications.q.yml">quintessence/AllegroFlare/Notifications.q.yml</a></li>
   <li><a href="#quintessence/AllegroFlare/NotificationsFactory.q.yml">quintessence/AllegroFlare/NotificationsFactory.q.yml</a></li>
@@ -4848,6 +4849,33 @@ table td
 <tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;ALLEGRO_BITMAP*&quot;, &quot;headers&quot;=&gt;[&quot;allegro5/allegro.h&quot;]}</td>
 </tr>
+    </table>
+  </div>
+</ul>
+<ul>
+  <div class="component">
+    <h3 id="quintessence/AllegroFlare/MultiMeshUV.q.yml">quintessence/AllegroFlare/MultiMeshUV.q.yml</h3>
+     <table>
+<tr>
+  <td class="property">u1</td>
+  <td class="property">float</td>
+</tr>
+<tr>
+  <td class="property">v1</td>
+  <td class="property">float</td>
+</tr>
+<tr>
+  <td class="property">u2</td>
+  <td class="property">float</td>
+</tr>
+<tr>
+  <td class="property">v2</td>
+  <td class="property">float</td>
+</tr>
+    </table>
+     <table>
+    </table>
+     <table>
     </table>
   </div>
 </ul>

--- a/include/AllegroFlare/MultiMesh.hpp
+++ b/include/AllegroFlare/MultiMesh.hpp
@@ -18,6 +18,8 @@ namespace AllegroFlare
       ~MultiMesh();
 
       void initialize();
+      void append();
+      void remove();
       void render();
    };
 }

--- a/include/AllegroFlare/MultiMesh.hpp
+++ b/include/AllegroFlare/MultiMesh.hpp
@@ -11,21 +11,24 @@ namespace AllegroFlare
    class MultiMesh
    {
    private:
-      ALLEGRO_VERTEX_BUFFER* vertex_buffer;
-      ALLEGRO_BITMAP* texture;
       int num_items;
+      ALLEGRO_VERTEX_BUFFER* vertex_buffer;
+      ALLEGRO_VERTEX_DECL* vertex_decl;
+      ALLEGRO_BITMAP* texture;
       int vertices_in_use;
       int VERTEXES_PER_ITEM;
       AllegroFlare::MultiMeshUVAtlas atlas;
       bool initialized;
 
    public:
-      MultiMesh();
+      MultiMesh(int num_items=256);
       ~MultiMesh();
 
       void set_texture(ALLEGRO_BITMAP* texture);
+      int get_num_items() const;
       ALLEGRO_BITMAP* get_texture() const;
       void set_atlas(AllegroFlare::MultiMeshUVAtlas atlas={});
+      void set_num_items(int num_items=256);
       void initialize();
       void append(int atlas_item_index_num=0, float x=0, float y=0);
       void append_raw(float x=0, float y=0, float w=1, float h=1, float u1=100.0f, float v1=100.0f, float u2=200.0f, float v2=200.0f);

--- a/include/AllegroFlare/MultiMesh.hpp
+++ b/include/AllegroFlare/MultiMesh.hpp
@@ -27,8 +27,8 @@ namespace AllegroFlare
       ALLEGRO_BITMAP* get_texture() const;
       void set_atlas(AllegroFlare::MultiMeshUVAtlas atlas={});
       void initialize();
-      void append_item_from_atlas_index(int atlas_item_index_num=0, float x=0, float y=0);
-      void append(float x=0, float y=0, float w=1, float h=1, float u1=100.0f, float v1=100.0f, float u2=200.0f, float v2=200.0f);
+      void append(int atlas_item_index_num=0, float x=0, float y=0);
+      void append_raw(float x=0, float y=0, float w=1, float h=1, float u1=100.0f, float v1=100.0f, float u2=200.0f, float v2=200.0f);
       int remove(int item_index=0);
       void render();
    };

--- a/include/AllegroFlare/MultiMesh.hpp
+++ b/include/AllegroFlare/MultiMesh.hpp
@@ -11,7 +11,6 @@ namespace AllegroFlare
    {
    private:
       ALLEGRO_VERTEX_BUFFER* vertex_buffer;
-      ALLEGRO_INDEX_BUFFER* index_buffer;
       ALLEGRO_BITMAP* texture;
       int indexes_in_use;
       int VERTEXES_PER_ITEM;

--- a/include/AllegroFlare/MultiMesh.hpp
+++ b/include/AllegroFlare/MultiMesh.hpp
@@ -12,7 +12,7 @@ namespace AllegroFlare
    private:
       ALLEGRO_VERTEX_BUFFER* vertex_buffer;
       ALLEGRO_BITMAP* texture;
-      int indexes_in_use;
+      int vertices_in_use;
       int VERTEXES_PER_ITEM;
       bool initialized;
 

--- a/include/AllegroFlare/MultiMesh.hpp
+++ b/include/AllegroFlare/MultiMesh.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+
+#include <allegro5/allegro_primitives.h>
+
+
+namespace AllegroFlare
+{
+   class MultiMesh
+   {
+   private:
+      ALLEGRO_VERTEX_BUFFER* vertex_buffer;
+      ALLEGRO_INDEX_BUFFER* index_buffer;
+      bool initialized;
+
+   public:
+      MultiMesh();
+      ~MultiMesh();
+
+      void initialize();
+      void render();
+   };
+}
+
+
+

--- a/include/AllegroFlare/MultiMesh.hpp
+++ b/include/AllegroFlare/MultiMesh.hpp
@@ -14,6 +14,7 @@ namespace AllegroFlare
       ALLEGRO_INDEX_BUFFER* index_buffer;
       ALLEGRO_BITMAP* texture;
       int indexes_in_use;
+      int VERTEXES_PER_ITEM;
       bool initialized;
 
    public:

--- a/include/AllegroFlare/MultiMesh.hpp
+++ b/include/AllegroFlare/MultiMesh.hpp
@@ -24,7 +24,7 @@ namespace AllegroFlare
       void set_texture(ALLEGRO_BITMAP* texture);
       ALLEGRO_BITMAP* get_texture() const;
       void initialize();
-      void append(float x=0, float y=0, float w=1, float h=1);
+      void append(float x=0, float y=0, float w=1, float h=1, float u1=100.0f, float v1=100.0f, float u2=200.0f, float v2=200.0f);
       void remove(int at_index=0);
       void render();
    };

--- a/include/AllegroFlare/MultiMesh.hpp
+++ b/include/AllegroFlare/MultiMesh.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 
+#include <AllegroFlare/MultiMeshUVAtlas.hpp>
 #include <allegro5/allegro.h>
 #include <allegro5/allegro_primitives.h>
 
@@ -15,6 +16,7 @@ namespace AllegroFlare
       int num_items;
       int vertices_in_use;
       int VERTEXES_PER_ITEM;
+      AllegroFlare::MultiMeshUVAtlas atlas;
       bool initialized;
 
    public:
@@ -23,7 +25,9 @@ namespace AllegroFlare
 
       void set_texture(ALLEGRO_BITMAP* texture);
       ALLEGRO_BITMAP* get_texture() const;
+      void set_atlas(AllegroFlare::MultiMeshUVAtlas atlas={});
       void initialize();
+      void append_item_from_atlas_index(int atlas_item_index_num=0, float x=0, float y=0);
       void append(float x=0, float y=0, float w=1, float h=1, float u1=100.0f, float v1=100.0f, float u2=200.0f, float v2=200.0f);
       int remove(int item_index=0);
       void render();

--- a/include/AllegroFlare/MultiMesh.hpp
+++ b/include/AllegroFlare/MultiMesh.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 
+#include <allegro5/allegro.h>
 #include <allegro5/allegro_primitives.h>
 
 
@@ -11,6 +12,7 @@ namespace AllegroFlare
    private:
       ALLEGRO_VERTEX_BUFFER* vertex_buffer;
       ALLEGRO_INDEX_BUFFER* index_buffer;
+      ALLEGRO_BITMAP* texture;
       int indexes_in_use;
       bool initialized;
 
@@ -18,6 +20,8 @@ namespace AllegroFlare
       MultiMesh();
       ~MultiMesh();
 
+      void set_texture(ALLEGRO_BITMAP* texture);
+      ALLEGRO_BITMAP* get_texture() const;
       void initialize();
       void append(float x=0, float y=0, float w=1, float h=1);
       void remove(int at_index=0);

--- a/include/AllegroFlare/MultiMesh.hpp
+++ b/include/AllegroFlare/MultiMesh.hpp
@@ -24,7 +24,7 @@ namespace AllegroFlare
       ALLEGRO_BITMAP* get_texture() const;
       void initialize();
       void append(float x=0, float y=0, float w=1, float h=1, float u1=100.0f, float v1=100.0f, float u2=200.0f, float v2=200.0f);
-      void remove(int at_index=0);
+      void remove(int item_index=0);
       void render();
    };
 }

--- a/include/AllegroFlare/MultiMesh.hpp
+++ b/include/AllegroFlare/MultiMesh.hpp
@@ -25,7 +25,7 @@ namespace AllegroFlare
       ALLEGRO_BITMAP* get_texture() const;
       void initialize();
       void append(float x=0, float y=0, float w=1, float h=1, float u1=100.0f, float v1=100.0f, float u2=200.0f, float v2=200.0f);
-      void remove(int item_index=0);
+      int remove(int item_index=0);
       void render();
    };
 }

--- a/include/AllegroFlare/MultiMesh.hpp
+++ b/include/AllegroFlare/MultiMesh.hpp
@@ -12,6 +12,7 @@ namespace AllegroFlare
    private:
       ALLEGRO_VERTEX_BUFFER* vertex_buffer;
       ALLEGRO_BITMAP* texture;
+      int num_items;
       int vertices_in_use;
       int VERTEXES_PER_ITEM;
       bool initialized;

--- a/include/AllegroFlare/MultiMesh.hpp
+++ b/include/AllegroFlare/MultiMesh.hpp
@@ -11,6 +11,7 @@ namespace AllegroFlare
    private:
       ALLEGRO_VERTEX_BUFFER* vertex_buffer;
       ALLEGRO_INDEX_BUFFER* index_buffer;
+      int indexes_in_use;
       bool initialized;
 
    public:
@@ -18,8 +19,8 @@ namespace AllegroFlare
       ~MultiMesh();
 
       void initialize();
-      void append();
-      void remove();
+      void append(float x=0, float y=0, float w=1, float h=1);
+      void remove(int at_index=0);
       void render();
    };
 }

--- a/include/AllegroFlare/MultiMesh.hpp
+++ b/include/AllegroFlare/MultiMesh.hpp
@@ -4,6 +4,7 @@
 #include <AllegroFlare/MultiMeshUVAtlas.hpp>
 #include <allegro5/allegro.h>
 #include <allegro5/allegro_primitives.h>
+#include <cstddef>
 
 
 namespace AllegroFlare
@@ -11,7 +12,7 @@ namespace AllegroFlare
    class MultiMesh
    {
    private:
-      int num_items;
+      std::size_t num_items;
       ALLEGRO_VERTEX_BUFFER* vertex_buffer;
       ALLEGRO_VERTEX_DECL* vertex_decl;
       ALLEGRO_BITMAP* texture;
@@ -21,14 +22,14 @@ namespace AllegroFlare
       bool initialized;
 
    public:
-      MultiMesh(int num_items=256);
+      MultiMesh(std::size_t num_items=256);
       ~MultiMesh();
 
       void set_texture(ALLEGRO_BITMAP* texture);
-      int get_num_items() const;
+      std::size_t get_num_items() const;
       ALLEGRO_BITMAP* get_texture() const;
       void set_atlas(AllegroFlare::MultiMeshUVAtlas atlas={});
-      void set_num_items(int num_items=256);
+      void set_num_items(std::size_t num_items=256);
       void initialize();
       void append(int atlas_item_index_num=0, float x=0, float y=0);
       void append_raw(float x=0, float y=0, float w=1, float h=1, float u1=100.0f, float v1=100.0f, float u2=200.0f, float v2=200.0f);

--- a/include/AllegroFlare/MultiMeshUV.hpp
+++ b/include/AllegroFlare/MultiMeshUV.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+
+
+
+namespace AllegroFlare
+{
+   class MultiMeshUV
+   {
+   private:
+      float u1;
+      float v1;
+      float u2;
+      float v2;
+
+   public:
+      MultiMeshUV(float u1=0, float v1=0, float u2=0, float v2=0);
+      ~MultiMeshUV();
+
+      void set_u1(float u1);
+      void set_v1(float v1);
+      void set_u2(float u2);
+      void set_v2(float v2);
+      float get_u1() const;
+      float get_v1() const;
+      float get_u2() const;
+      float get_v2() const;
+   };
+}
+
+
+

--- a/include/AllegroFlare/MultiMeshUV.hpp
+++ b/include/AllegroFlare/MultiMeshUV.hpp
@@ -25,6 +25,8 @@ namespace AllegroFlare
       float get_v1() const;
       float get_u2() const;
       float get_v2() const;
+      float infer_width();
+      float infer_height();
    };
 }
 

--- a/include/AllegroFlare/MultiMeshUVAtlas.hpp
+++ b/include/AllegroFlare/MultiMeshUVAtlas.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+
+#include <AllegroFlare/MultiMeshUV.hpp>
+#include <map>
+
+
+namespace AllegroFlare
+{
+   class MultiMeshUVAtlas
+   {
+   private:
+      std::map<int, AllegroFlare::MultiMeshUV> index;
+
+   public:
+      MultiMeshUVAtlas(std::map<int, AllegroFlare::MultiMeshUV> index={});
+      ~MultiMeshUVAtlas();
+
+      void set_index(std::map<int, AllegroFlare::MultiMeshUV> index);
+      std::map<int, AllegroFlare::MultiMeshUV> get_index() const;
+   };
+}
+
+
+

--- a/include/AllegroFlare/MultiMeshUVAtlas.hpp
+++ b/include/AllegroFlare/MultiMeshUVAtlas.hpp
@@ -2,6 +2,7 @@
 
 
 #include <AllegroFlare/MultiMeshUV.hpp>
+#include <allegro5/allegro.h>
 #include <map>
 
 
@@ -10,13 +11,16 @@ namespace AllegroFlare
    class MultiMeshUVAtlas
    {
    private:
+      ALLEGRO_BITMAP* bitmap;
       std::map<int, AllegroFlare::MultiMeshUV> index;
 
    public:
-      MultiMeshUVAtlas(std::map<int, AllegroFlare::MultiMeshUV> index={});
+      MultiMeshUVAtlas(ALLEGRO_BITMAP* bitmap=nullptr, std::map<int, AllegroFlare::MultiMeshUV> index={});
       ~MultiMeshUVAtlas();
 
+      void set_bitmap(ALLEGRO_BITMAP* bitmap);
       void set_index(std::map<int, AllegroFlare::MultiMeshUV> index);
+      ALLEGRO_BITMAP* get_bitmap() const;
       std::map<int, AllegroFlare::MultiMeshUV> get_index() const;
       void add(int index_num=0, float u1=0.0f, float v1=0.0f, float u2=1.0f, float v2=1.0f);
       bool exists(int index_num=0);

--- a/include/AllegroFlare/MultiMeshUVAtlas.hpp
+++ b/include/AllegroFlare/MultiMeshUVAtlas.hpp
@@ -18,6 +18,9 @@ namespace AllegroFlare
 
       void set_index(std::map<int, AllegroFlare::MultiMeshUV> index);
       std::map<int, AllegroFlare::MultiMeshUV> get_index() const;
+      void add(int index_num=0, float u1=0.0f, float v1=0.0f, float u2=1.0f, float v2=1.0f);
+      bool exists(int index_num=0);
+      AllegroFlare::MultiMeshUV get(int index_num=0);
    };
 }
 

--- a/include/AllegroFlare/MultiMeshUVAtlas.hpp
+++ b/include/AllegroFlare/MultiMeshUVAtlas.hpp
@@ -2,7 +2,6 @@
 
 
 #include <AllegroFlare/MultiMeshUV.hpp>
-#include <allegro5/allegro.h>
 #include <map>
 
 
@@ -11,16 +10,13 @@ namespace AllegroFlare
    class MultiMeshUVAtlas
    {
    private:
-      ALLEGRO_BITMAP* bitmap;
       std::map<int, AllegroFlare::MultiMeshUV> index;
 
    public:
-      MultiMeshUVAtlas(ALLEGRO_BITMAP* bitmap=nullptr, std::map<int, AllegroFlare::MultiMeshUV> index={});
+      MultiMeshUVAtlas(std::map<int, AllegroFlare::MultiMeshUV> index={});
       ~MultiMeshUVAtlas();
 
-      void set_bitmap(ALLEGRO_BITMAP* bitmap);
       void set_index(std::map<int, AllegroFlare::MultiMeshUV> index);
-      ALLEGRO_BITMAP* get_bitmap() const;
       std::map<int, AllegroFlare::MultiMeshUV> get_index() const;
       void add(int index_num=0, float u1=0.0f, float v1=0.0f, float u2=1.0f, float v2=1.0f);
       bool exists(int index_num=0);

--- a/include/AllegroFlare/Network2/Message.hpp
+++ b/include/AllegroFlare/Network2/Message.hpp
@@ -12,9 +12,11 @@ namespace AllegroFlare
    {
       class Message
       {
+      public:
+         static constexpr std::size_t HEADER_LENGTH = 16;
+         static constexpr std::size_t MAX_BODY_LENGTH = 512;
+
       private:
-         static std::size_t HEADER_LENGTH;
-         static std::size_t MAX_BODY_LENGTH;
          static std::string MAGIC_HEADER_CHUNK;
          std::string data;
          std::size_t body_length;
@@ -23,8 +25,6 @@ namespace AllegroFlare
          Message();
          ~Message();
 
-         static std::size_t get_HEADER_LENGTH();
-         static std::size_t get_MAX_BODY_LENGTH();
          static std::string get_MAGIC_HEADER_CHUNK();
          std::string get_data() const;
          std::size_t get_body_length() const;

--- a/legacy/examples/network_chat_server.cpp
+++ b/legacy/examples/network_chat_server.cpp
@@ -144,7 +144,7 @@ private:
           {
 			  // here, I believe, is where a message would be intercepted and parsed
 			  // this is a message that has been sent BY the client TO the server, and
-			  // this app is then responding HERE by delivering the mssage to all the
+			  // this app is then responding *here* by delivering the mssage to all the
 			  // users in the room.
 			  read_msg_.set_sender_id(self->get_user_id()); // ?? should this be self->get_user_id() or this->get_user_id()?
             room_.deliver(read_msg_);

--- a/quintessence/AllegroFlare/MultiMesh.q.yml
+++ b/quintessence/AllegroFlare/MultiMesh.q.yml
@@ -9,6 +9,12 @@ properties:
     type: ALLEGRO_INDEX_BUFFER*
     init_with: nullptr
 
+  - name: texture
+    type: ALLEGRO_BITMAP*
+    init_with: nullptr
+    getter: true
+    setter: true
+
   - name: indexes_in_use
     type: int
     init_with: 0
@@ -73,8 +79,13 @@ functions:
       - name: h
         type: float
         default_argument: 1
+    guards: [ initialized ]
     body: |
       // TODO
+      // lock
+      // fill 6 vertexes @ indexs
+      // unlock
+      // increase indexes_in_use by 6
       return;
 
 
@@ -83,17 +94,21 @@ functions:
       - name: at_index
         type: int
         default_argument: 0
+    guards: [ initialized ]
     body: |
       // TODO
+      // lock @ index to indexes_in_use
+      // copy vertexes from end into removed position (if not already at end)
+      // reduce indexes_in_use by 6
+      // unlock
       return;
 
 
   - name: render
     guards: [ initialized ]
     body: |
-      //int al_draw_indexed_buffer(ALLEGRO_VERTEX_BUFFER* vertex_buffer,
-         //ALLEGRO_BITMAP* texture, ALLEGRO_INDEX_BUFFER* index_buffer,
-         //int start, int end, int type)
+      if (indexes_in_use == 0) return;
+      al_draw_indexed_buffer(vertex_buffer, texture, index_buffer, 0, indexes_in_use, ALLEGRO_PRIM_TRIANGLE_LIST);
       return;
 
 
@@ -104,5 +119,7 @@ dependencies:
     headers: [ allegro5/allegro_primitives.h ]
   - symbol: ALLEGRO_INDEX_BUFFER*
     headers: [ allegro5/allegro_primitives.h ]
+  - symbol: ALLEGRO_BITMAP*
+    headers: [ allegro5/allegro.h ]
 
 

--- a/quintessence/AllegroFlare/MultiMesh.q.yml
+++ b/quintessence/AllegroFlare/MultiMesh.q.yml
@@ -26,8 +26,8 @@ properties:
 
   - name: atlas
     type: AllegroFlare::MultiMeshUVAtlas
-    init_with: '{}'
-    setter: explicit
+    init_with: ''
+    setter: false
 
   - name: initialized
     type: bool
@@ -87,7 +87,7 @@ functions:
         type: float
         default_argument: 0
     body: |
-      AllegroFlare::MultiMeshUV atlas_uv = atlas.get(atlas_item_index_num);
+      AllegroFlare::MultiMeshUV atlas_item = atlas.get(atlas_item_index_num);
       append(
          x,
          y,

--- a/quintessence/AllegroFlare/MultiMesh.q.yml
+++ b/quintessence/AllegroFlare/MultiMesh.q.yml
@@ -24,12 +24,28 @@ properties:
     type: int
     init_with: 6
 
+  - name: atlas
+    type: AllegroFlare::MultiMeshUVAtlas
+    init_with: '{}'
+    setter: explicit
+
   - name: initialized
     type: bool
     init_with: false
 
 
 functions:
+
+
+  - name: set_atlas
+    parameters:
+      - name: atlas
+        type: AllegroFlare::MultiMeshUVAtlas
+        default_argument: '{}'
+    guards: [ (!initialized) ]
+    body: |
+      this->atlas = atlas;
+      return;
 
 
   - name: initialize
@@ -167,5 +183,7 @@ dependencies:
     headers: [ allegro5/allegro_primitives.h ]
   - symbol: ALLEGRO_BITMAP*
     headers: [ allegro5/allegro.h ]
+  - symbol: AllegroFlare::MultiMeshUVAtlas
+    headers: [ AllegroFlare/MultiMeshUVAtlas.hpp ]
 
 

--- a/quintessence/AllegroFlare/MultiMesh.q.yml
+++ b/quintessence/AllegroFlare/MultiMesh.q.yml
@@ -20,13 +20,59 @@ functions:
   - name: initialize
     guards: [ (!initialized), al_is_system_installed(), al_is_primitives_addon_initialized() ]
     body: |
+      int num_elements = 50;
+      int num_vertices = num_elements * 6;
+
+      // create the vertex declaration
+      ALLEGRO_VERTEX_ELEMENT elems[] = {
+         {ALLEGRO_PRIM_POSITION, ALLEGRO_PRIM_FLOAT_3, offsetof(ALLEGRO_VERTEX, x)},
+         {ALLEGRO_PRIM_TEX_COORD_PIXEL, ALLEGRO_PRIM_FLOAT_2, offsetof(ALLEGRO_VERTEX, u)},
+         {ALLEGRO_PRIM_COLOR_ATTR, 0, offsetof(ALLEGRO_VERTEX, color)},
+         {0, 0, 0}
+      };
+      ALLEGRO_VERTEX_DECL* decl = al_create_vertex_decl(elems, sizeof(ALLEGRO_VERTEX));
+
+      // vertex buffer, data will be uninitialized
+      const void* initial_data_vb = nullptr;
+      vertex_buffer = al_create_vertex_buffer(
+         decl,
+         initial_data_vb,
+         num_vertices,
+         ALLEGRO_PRIM_BUFFER_READWRITE
+      );
+
+      // index buffer, data will be uninitialized
+      // size of the buffer is 2, which is a short, limiting the size to a certain amount (TODO, figure out amount)
+      const void* initial_data_ib = nullptr;
+      index_buffer = al_create_index_buffer(
+         sizeof(short),
+         initial_data_ib,
+         num_vertices,
+         ALLEGRO_PRIM_BUFFER_READWRITE
+      );
+
       initialized = true;
+      return;
+
+
+  - name: append
+    body: |
+      // TODO
+      return;
+
+
+  - name: remove
+    body: |
+      // TODO
       return;
 
 
   - name: render
     guards: [ initialized ]
     body: |
+      //int al_draw_indexed_buffer(ALLEGRO_VERTEX_BUFFER* vertex_buffer,
+         //ALLEGRO_BITMAP* texture, ALLEGRO_INDEX_BUFFER* index_buffer,
+         //int start, int end, int type)
       return;
 
 

--- a/quintessence/AllegroFlare/MultiMesh.q.yml
+++ b/quintessence/AllegroFlare/MultiMesh.q.yml
@@ -75,7 +75,7 @@ functions:
       return;
 
 
-  - name: append_item_from_atlas_index
+  - name: append
     parameters:
       - name: atlas_item_index_num
         type: int
@@ -88,7 +88,7 @@ functions:
         default_argument: 0
     body: |
       AllegroFlare::MultiMeshUV atlas_item = atlas.get(atlas_item_index_num);
-      append(
+      append_raw(
          x,
          y,
          atlas_item.infer_width(),
@@ -101,7 +101,7 @@ functions:
       return;
 
 
-  - name: append
+  - name: append_raw
     parameters:
       - name: x
         type: float

--- a/quintessence/AllegroFlare/MultiMesh.q.yml
+++ b/quintessence/AllegroFlare/MultiMesh.q.yml
@@ -166,8 +166,7 @@ functions:
         default_argument: 0
     guards: [ initialized ]
     body: |
-      // TODO
-      // validate position exists, does not overflow, etc
+      // TODO: validate position exists, does not overflow, etc
       int item_start_index = item_index * VERTEXES_PER_ITEM;
       int length = vertices_in_use - item_start_index; // all the way to the end of vertices_in_use
       bool removed_vertex_is_at_end = (item_start_index == vertices_in_use-VERTEXES_PER_ITEM);

--- a/quintessence/AllegroFlare/MultiMesh.q.yml
+++ b/quintessence/AllegroFlare/MultiMesh.q.yml
@@ -1,0 +1,41 @@
+properties:
+
+
+  - name: vertex_buffer
+    type: ALLEGRO_VERTEX_BUFFER*
+    init_with: nullptr
+
+  - name: index_buffer
+    type: ALLEGRO_INDEX_BUFFER*
+    init_with: nullptr
+
+  - name: initialized
+    type: bool
+    init_with: false
+
+
+functions:
+
+
+  - name: initialize
+    guards: [ (!initialized), al_is_system_installed(), al_is_primitives_addon_initialized() ]
+    body: |
+      initialized = true;
+      return;
+
+
+  - name: render
+    guards: [ initialized ]
+    body: |
+      return;
+
+
+dependencies:
+
+
+  - symbol: ALLEGRO_VERTEX_BUFFER*
+    headers: [ allegro5/allegro_primitives.h ]
+  - symbol: ALLEGRO_INDEX_BUFFER*
+    headers: [ allegro5/allegro_primitives.h ]
+
+

--- a/quintessence/AllegroFlare/MultiMesh.q.yml
+++ b/quintessence/AllegroFlare/MultiMesh.q.yml
@@ -117,6 +117,7 @@ functions:
 
 
   - name: remove
+    type: int
     parameters:
       - name: item_index
         type: int
@@ -127,6 +128,7 @@ functions:
       // validate position exists, does not overflow, etc
       int item_start_index = item_index * VERTEXES_PER_ITEM;
       int length = vertices_in_use - item_start_index; // all the way to the end of vertices_in_use
+      bool removed_vertex_is_at_end = (item_start_index == vertices_in_use-VERTEXES_PER_ITEM);
 
       // lock @ index to vertices_in_use
       ALLEGRO_VERTEX* start = (ALLEGRO_VERTEX*)al_lock_vertex_buffer(
@@ -137,14 +139,15 @@ functions:
       );
 
       // copy vertexes from end (end-6) into removed position (if not already at end)
-      for (int i=0; i<6; i++) start[i] = start[i + length-6];
+      if (!removed_vertex_is_at_end) for (int i=0; i<6; i++) start[i] = start[i + length-VERTEXES_PER_ITEM];
 
       // unlock
       al_unlock_vertex_buffer(vertex_buffer);
 
       // reduce vertices_in_use by 6
       vertices_in_use -= 6;
-      return;
+      if (removed_vertex_is_at_end) return item_index;
+      return vertices_in_use / VERTEXES_PER_ITEM;
 
 
   - name: render

--- a/quintessence/AllegroFlare/MultiMesh.q.yml
+++ b/quintessence/AllegroFlare/MultiMesh.q.yml
@@ -9,6 +9,10 @@ properties:
     type: ALLEGRO_INDEX_BUFFER*
     init_with: nullptr
 
+  - name: indexes_in_use
+    type: int
+    init_with: 0
+
   - name: initialized
     type: bool
     init_with: false
@@ -56,12 +60,29 @@ functions:
 
 
   - name: append
+    parameters:
+      - name: x
+        type: float
+        default_argument: 0
+      - name: y
+        type: float
+        default_argument: 0
+      - name: w
+        type: float
+        default_argument: 1
+      - name: h
+        type: float
+        default_argument: 1
     body: |
       // TODO
       return;
 
 
   - name: remove
+    parameters:
+      - name: at_index
+        type: int
+        default_argument: 0
     body: |
       // TODO
       return;

--- a/quintessence/AllegroFlare/MultiMesh.q.yml
+++ b/quintessence/AllegroFlare/MultiMesh.q.yml
@@ -5,10 +5,6 @@ properties:
     type: ALLEGRO_VERTEX_BUFFER*
     init_with: nullptr
 
-  - name: index_buffer
-    type: ALLEGRO_INDEX_BUFFER*
-    init_with: nullptr
-
   - name: texture
     type: ALLEGRO_BITMAP*
     init_with: nullptr
@@ -52,16 +48,6 @@ functions:
       vertex_buffer = al_create_vertex_buffer(
          decl,
          initial_data_vb,
-         num_vertices,
-         ALLEGRO_PRIM_BUFFER_READWRITE
-      );
-
-      // index buffer, data will be uninitialized
-      // size of the buffer is 2, which is a short, limiting the size to a certain amount (TODO, figure out amount)
-      const void* initial_data_ib = nullptr;
-      index_buffer = al_create_index_buffer(
-         sizeof(short),
-         initial_data_ib,
          num_vertices,
          ALLEGRO_PRIM_BUFFER_READWRITE
       );
@@ -146,7 +132,6 @@ functions:
     body: |
       if (indexes_in_use == 0) return;
       al_draw_vertex_buffer(vertex_buffer, texture, 0, indexes_in_use, ALLEGRO_PRIM_TRIANGLE_LIST);
-      //al_draw_indexed_buffer(vertex_buffer, texture, index_buffer, 0, indexes_in_use, ALLEGRO_PRIM_TRIANGLE_LIST);
       return;
 
 

--- a/quintessence/AllegroFlare/MultiMesh.q.yml
+++ b/quintessence/AllegroFlare/MultiMesh.q.yml
@@ -1,8 +1,19 @@
 properties:
 
 
+  - name: num_items
+    type: int
+    init_with: 256
+    constructor_arg: true
+    getter: true
+    setter: false
+
   - name: vertex_buffer
     type: ALLEGRO_VERTEX_BUFFER*
+    init_with: nullptr
+
+  - name: vertex_decl
+    type: ALLEGRO_VERTEX_DECL*
     init_with: nullptr
 
   - name: texture
@@ -10,10 +21,6 @@ properties:
     init_with: nullptr
     getter: true
     setter: true
-
-  - name: num_items
-    type: int
-    init_with: 50
 
   - name: vertices_in_use
     type: int
@@ -48,6 +55,17 @@ functions:
       return;
 
 
+  - name: set_num_items
+    parameters:
+      - name: num_items
+        type: int
+        default_argument: 256
+    guards: [ (!initialized) ]
+    body: |
+      this->num_items = num_items;
+      return;
+
+
   - name: initialize
     guards: [ (!initialized), al_is_system_installed(), al_is_primitives_addon_initialized() ]
     body: |
@@ -60,12 +78,12 @@ functions:
          {ALLEGRO_PRIM_COLOR_ATTR, 0, offsetof(ALLEGRO_VERTEX, color)},
          {0, 0, 0}
       };
-      ALLEGRO_VERTEX_DECL* decl = al_create_vertex_decl(elems, sizeof(ALLEGRO_VERTEX));
+      vertex_decl = al_create_vertex_decl(elems, sizeof(ALLEGRO_VERTEX));
 
       // vertex buffer, data will be uninitialized
       const void* initial_data_vb = nullptr;
       vertex_buffer = al_create_vertex_buffer(
-         decl,
+         vertex_decl,
          initial_data_vb,
          num_vertices,
          ALLEGRO_PRIM_BUFFER_READWRITE
@@ -202,6 +220,8 @@ functions:
 dependencies:
 
 
+  - symbol: ALLEGRO_VERTEX_DECL*
+    headers: [ allegro5/allegro_primitives.h ]
   - symbol: ALLEGRO_VERTEX_BUFFER*
     headers: [ allegro5/allegro_primitives.h ]
   - symbol: ALLEGRO_INDEX_BUFFER*

--- a/quintessence/AllegroFlare/MultiMesh.q.yml
+++ b/quintessence/AllegroFlare/MultiMesh.q.yml
@@ -19,6 +19,11 @@ properties:
     type: int
     init_with: 0
 
+  - name: VERTEXES_PER_ITEM
+    const: true
+    type: int
+    init_with: 6
+
   - name: initialized
     type: bool
     init_with: false
@@ -30,8 +35,8 @@ functions:
   - name: initialize
     guards: [ (!initialized), al_is_system_installed(), al_is_primitives_addon_initialized() ]
     body: |
-      int num_elements = 50;
-      int num_vertices = num_elements * 6;
+      int num_items = 50;
+      int num_vertices = num_items * VERTEXES_PER_ITEM;
 
       // create the vertex declaration
       ALLEGRO_VERTEX_ELEMENT elems[] = {
@@ -82,10 +87,34 @@ functions:
     guards: [ initialized ]
     body: |
       // TODO
-      // lock
+      float u1 = 0.1f;
+      float v1 = 0.1f;
+      float u2 = 0.2f;
+      float v2 = 0.2f;
+      ALLEGRO_COLOR color{1, 1, 1, 1};
+      ALLEGRO_VERTEX item_vertexes[6] = {
+         ALLEGRO_VERTEX{x+0, y+0, 0, u1, v1, color},
+         ALLEGRO_VERTEX{x+0, y+h, 0, u1, v1, color},
+         ALLEGRO_VERTEX{x+w, y+0, 0, u1, v1, color},
+         ALLEGRO_VERTEX{x+w, y+0, 0, u1, v1, color},
+         ALLEGRO_VERTEX{x+0, y+h, 0, u1, v1, color},
+         ALLEGRO_VERTEX{x+w, y+h, 0, u1, v1, color},
+      };
+
+      ALLEGRO_VERTEX* start = (ALLEGRO_VERTEX*)al_lock_vertex_buffer(
+         vertex_buffer,
+         indexes_in_use,
+         VERTEXES_PER_ITEM,
+         ALLEGRO_LOCK_WRITEONLY
+      );
+
       // fill 6 vertexes @ indexs
+      for (int i=0; i<6; i++) start[i] = item_vertexes[i];
+
       // unlock
+      al_unlock_vertex_buffer(vertex_buffer);
       // increase indexes_in_use by 6
+      indexes_in_use += 6;
       return;
 
 

--- a/quintessence/AllegroFlare/MultiMesh.q.yml
+++ b/quintessence/AllegroFlare/MultiMesh.q.yml
@@ -75,6 +75,32 @@ functions:
       return;
 
 
+  - name: append_item_from_atlas_index
+    parameters:
+      - name: atlas_item_index_num
+        type: int
+        default_argument: 0
+      - name: x
+        type: float
+        default_argument: 0
+      - name: y
+        type: float
+        default_argument: 0
+    body: |
+      AllegroFlare::MultiMeshUV atlas_uv = atlas.get(atlas_item_index_num);
+      append(
+         x,
+         y,
+         atlas_item.infer_width(),
+         atlas_item.infer_height(),
+         atlas_item.get_u1(),
+         atlas_item.get_v1(),
+         atlas_item.get_u2(),
+         atlas_item.get_v2()
+      );
+      return;
+
+
   - name: append
     parameters:
       - name: x

--- a/quintessence/AllegroFlare/MultiMesh.q.yml
+++ b/quintessence/AllegroFlare/MultiMesh.q.yml
@@ -86,19 +86,18 @@ functions:
         default_argument: 1
     guards: [ initialized ]
     body: |
-      // TODO
-      float u1 = 0.1f;
-      float v1 = 0.1f;
-      float u2 = 0.2f;
-      float v2 = 0.2f;
+      float u1 = 100.0f; // uvs using pixel coorindates; TODO: revise
+      float v1 = 100.0f;
+      float u2 = 200.0f;
+      float v2 = 200.0f;
       ALLEGRO_COLOR color{1, 1, 1, 1};
       ALLEGRO_VERTEX item_vertexes[6] = {
          ALLEGRO_VERTEX{x+0, y+0, 0, u1, v1, color},
-         ALLEGRO_VERTEX{x+0, y+h, 0, u1, v1, color},
-         ALLEGRO_VERTEX{x+w, y+0, 0, u1, v1, color},
-         ALLEGRO_VERTEX{x+w, y+0, 0, u1, v1, color},
-         ALLEGRO_VERTEX{x+0, y+h, 0, u1, v1, color},
-         ALLEGRO_VERTEX{x+w, y+h, 0, u1, v1, color},
+         ALLEGRO_VERTEX{x+0, y+h, 0, u1, v2, color},
+         ALLEGRO_VERTEX{x+w, y+0, 0, u2, v1, color},
+         ALLEGRO_VERTEX{x+w, y+0, 0, u2, v1, color},
+         ALLEGRO_VERTEX{x+0, y+h, 0, u1, v2, color},
+         ALLEGRO_VERTEX{x+w, y+h, 0, u2, v2, color},
       };
 
       ALLEGRO_VERTEX* start = (ALLEGRO_VERTEX*)al_lock_vertex_buffer(
@@ -137,7 +136,8 @@ functions:
     guards: [ initialized ]
     body: |
       if (indexes_in_use == 0) return;
-      al_draw_indexed_buffer(vertex_buffer, texture, index_buffer, 0, indexes_in_use, ALLEGRO_PRIM_TRIANGLE_LIST);
+      al_draw_vertex_buffer(vertex_buffer, texture, 0, indexes_in_use, ALLEGRO_PRIM_TRIANGLE_LIST);
+      //al_draw_indexed_buffer(vertex_buffer, texture, index_buffer, 0, indexes_in_use, ALLEGRO_PRIM_TRIANGLE_LIST);
       return;
 
 

--- a/quintessence/AllegroFlare/MultiMesh.q.yml
+++ b/quintessence/AllegroFlare/MultiMesh.q.yml
@@ -84,12 +84,20 @@ functions:
       - name: h
         type: float
         default_argument: 1
+      - name: u1
+        type: float
+        default_argument: 100.0f
+      - name: v1
+        type: float
+        default_argument: 100.0f
+      - name: u2
+        type: float
+        default_argument: 200.0f
+      - name: v2
+        type: float
+        default_argument: 200.0f
     guards: [ initialized ]
     body: |
-      float u1 = 100.0f; // uvs using pixel coorindates; TODO: revise
-      float v1 = 100.0f;
-      float u2 = 200.0f;
-      float v2 = 200.0f;
       ALLEGRO_COLOR color{1, 1, 1, 1};
       ALLEGRO_VERTEX item_vertexes[6] = {
          ALLEGRO_VERTEX{x+0, y+0, 0, u1, v1, color},
@@ -112,6 +120,7 @@ functions:
 
       // unlock
       al_unlock_vertex_buffer(vertex_buffer);
+
       // increase indexes_in_use by 6
       indexes_in_use += 6;
       return;

--- a/quintessence/AllegroFlare/MultiMesh.q.yml
+++ b/quintessence/AllegroFlare/MultiMesh.q.yml
@@ -115,7 +115,7 @@ functions:
 
   - name: remove
     parameters:
-      - name: at_index
+      - name: item_index
         type: int
         default_argument: 0
     guards: [ initialized ]

--- a/quintessence/AllegroFlare/MultiMesh.q.yml
+++ b/quintessence/AllegroFlare/MultiMesh.q.yml
@@ -11,6 +11,10 @@ properties:
     getter: true
     setter: true
 
+  - name: num_items
+    type: int
+    init_with: 50
+
   - name: vertices_in_use
     type: int
     init_with: 0
@@ -31,7 +35,6 @@ functions:
   - name: initialize
     guards: [ (!initialized), al_is_system_installed(), al_is_primitives_addon_initialized() ]
     body: |
-      int num_items = 50;
       int num_vertices = num_items * VERTEXES_PER_ITEM;
 
       // create the vertex declaration
@@ -121,10 +124,26 @@ functions:
     guards: [ initialized ]
     body: |
       // TODO
+      // validate position exists, does not overflow, etc
+      int item_start_index = item_index * VERTEXES_PER_ITEM;
+      int length = vertices_in_use - item_start_index; // all the way to the end of vertices_in_use
+
       // lock @ index to vertices_in_use
-      // copy vertexes from end into removed position (if not already at end)
-      // reduce vertices_in_use by 6
+      ALLEGRO_VERTEX* start = (ALLEGRO_VERTEX*)al_lock_vertex_buffer(
+         vertex_buffer,
+         item_start_index,
+         length,
+         ALLEGRO_LOCK_READWRITE
+      );
+
+      // copy vertexes from end (end-6) into removed position (if not already at end)
+      for (int i=0; i<6; i++) start[i] = start[i + length-6];
+
       // unlock
+      al_unlock_vertex_buffer(vertex_buffer);
+
+      // reduce vertices_in_use by 6
+      vertices_in_use -= 6;
       return;
 
 

--- a/quintessence/AllegroFlare/MultiMesh.q.yml
+++ b/quintessence/AllegroFlare/MultiMesh.q.yml
@@ -2,7 +2,7 @@ properties:
 
 
   - name: num_items
-    type: int
+    type: std::size_t
     init_with: 256
     constructor_arg: true
     getter: true
@@ -58,7 +58,7 @@ functions:
   - name: set_num_items
     parameters:
       - name: num_items
-        type: int
+        type: std::size_t
         default_argument: 256
     guards: [ (!initialized) ]
     body: |
@@ -230,5 +230,7 @@ dependencies:
     headers: [ allegro5/allegro.h ]
   - symbol: AllegroFlare::MultiMeshUVAtlas
     headers: [ AllegroFlare/MultiMeshUVAtlas.hpp ]
+  - symbol: std::size_t
+    headers: [ cstddef ]
 
 

--- a/quintessence/AllegroFlare/MultiMesh.q.yml
+++ b/quintessence/AllegroFlare/MultiMesh.q.yml
@@ -11,7 +11,7 @@ properties:
     getter: true
     setter: true
 
-  - name: indexes_in_use
+  - name: vertices_in_use
     type: int
     init_with: 0
 
@@ -94,21 +94,22 @@ functions:
          ALLEGRO_VERTEX{x+w, y+h, 0, u2, v2, color},
       };
 
+      // lock the vertex buffer
       ALLEGRO_VERTEX* start = (ALLEGRO_VERTEX*)al_lock_vertex_buffer(
          vertex_buffer,
-         indexes_in_use,
+         vertices_in_use,
          VERTEXES_PER_ITEM,
          ALLEGRO_LOCK_WRITEONLY
       );
 
-      // fill 6 vertexes @ indexs
+      // fill 6 vertexes @ ind
       for (int i=0; i<6; i++) start[i] = item_vertexes[i];
 
       // unlock
       al_unlock_vertex_buffer(vertex_buffer);
 
-      // increase indexes_in_use by 6
-      indexes_in_use += 6;
+      // increase vertices_in_use by 6
+      vertices_in_use += 6;
       return;
 
 
@@ -120,9 +121,9 @@ functions:
     guards: [ initialized ]
     body: |
       // TODO
-      // lock @ index to indexes_in_use
+      // lock @ index to vertices_in_use
       // copy vertexes from end into removed position (if not already at end)
-      // reduce indexes_in_use by 6
+      // reduce vertices_in_use by 6
       // unlock
       return;
 
@@ -130,8 +131,8 @@ functions:
   - name: render
     guards: [ initialized ]
     body: |
-      if (indexes_in_use == 0) return;
-      al_draw_vertex_buffer(vertex_buffer, texture, 0, indexes_in_use, ALLEGRO_PRIM_TRIANGLE_LIST);
+      if (vertices_in_use == 0) return;
+      al_draw_vertex_buffer(vertex_buffer, texture, 0, vertices_in_use, ALLEGRO_PRIM_TRIANGLE_LIST);
       return;
 
 

--- a/quintessence/AllegroFlare/MultiMeshUV.q.yml
+++ b/quintessence/AllegroFlare/MultiMeshUV.q.yml
@@ -30,3 +30,16 @@ properties:
     constructor_arg: true
 
 
+functions:
+
+
+  - name: infer_width
+    type: float
+    body: return u2-u1;
+
+
+  - name: infer_height
+    type: float
+    body: return v2-v1;
+
+

--- a/quintessence/AllegroFlare/MultiMeshUV.q.yml
+++ b/quintessence/AllegroFlare/MultiMeshUV.q.yml
@@ -1,0 +1,32 @@
+properties:
+
+
+  - name: u1
+    type: float
+    init_with: 0
+    getter: true
+    setter: true
+    constructor_arg: true
+
+  - name: v1
+    type: float
+    init_with: 0
+    getter: true
+    setter: true
+    constructor_arg: true
+
+  - name: u2
+    type: float
+    init_with: 0
+    getter: true
+    setter: true
+    constructor_arg: true
+
+  - name: v2
+    type: float
+    init_with: 0
+    getter: true
+    setter: true
+    constructor_arg: true
+
+

--- a/quintessence/AllegroFlare/MultiMeshUVAtlas.q.yml
+++ b/quintessence/AllegroFlare/MultiMeshUVAtlas.q.yml
@@ -1,0 +1,18 @@
+properties:
+
+
+  - name: index
+    type: std::map<int, AllegroFlare::MultiMeshUV>
+    init_with: '{}'
+    constructor_arg: true
+    getter: true
+    setter: true
+
+
+dependencies:
+
+
+  - symbol: std::map<int, AllegroFlare::MultiMeshUV>
+    headers: [ map, AllegroFlare/MultiMeshUV.hpp ]
+ 
+

--- a/quintessence/AllegroFlare/MultiMeshUVAtlas.q.yml
+++ b/quintessence/AllegroFlare/MultiMeshUVAtlas.q.yml
@@ -9,10 +9,68 @@ properties:
     setter: true
 
 
+functions:
+
+
+  - name: add
+    parameters:
+      - name: index_num
+        type: int
+        default_argument: 0
+      - name: u1
+        type: float
+        default_argument: 0.0f
+      - name: v1
+        type: float
+        default_argument: 0.0f
+      - name: u2
+        type: float
+        default_argument: 1.0f
+      - name: v2
+        type: float
+        default_argument: 1.0f
+    body: |
+      index[index_num] = AllegroFlare::MultiMeshUV(u1, v1, u2, v2);
+      return;
+
+
+  - name: exists
+    type: bool
+    parameters:
+      - name: index_num
+        type: int
+        default_argument: 0
+    body: |
+      return (index.count(index_num) == 1);
+
+
+  - name: get
+    type: AllegroFlare::MultiMeshUV
+    parameters:
+      - name: index_num
+        type: int
+        default_argument: 0
+    body: |
+      if (!exists(index_num))
+      {
+         std::stringstream error_message;
+         error_message << "AllegroFlare::MultiMeshUVAtlas::get error: "
+                       << "Item does not exist at index_num " << index_num << ". Returning a default MultiMeshUV.";
+         std::cout << error_message.str() << std::endl;
+         return AllegroFlare::MultiMeshUV();
+      }
+      return index[index_num];
+    body_dependency_symbols:
+      - std::stringstream
+      - std::cout
+
+
 dependencies:
 
 
   - symbol: std::map<int, AllegroFlare::MultiMeshUV>
     headers: [ map, AllegroFlare/MultiMeshUV.hpp ]
+  - symbol: AllegroFlare::MultiMeshUV
+    headers: [ AllegroFlare/MultiMeshUV.hpp ]
  
 

--- a/quintessence/AllegroFlare/MultiMeshUVAtlas.q.yml
+++ b/quintessence/AllegroFlare/MultiMeshUVAtlas.q.yml
@@ -1,6 +1,13 @@
 properties:
 
 
+  - name: bitmap
+    type: ALLEGRO_BITMAP*
+    init_with: nullptr
+    constructor_arg: true
+    getter: true
+    setter: true
+
   - name: index
     type: std::map<int, AllegroFlare::MultiMeshUV>
     init_with: '{}'
@@ -72,5 +79,7 @@ dependencies:
     headers: [ map, AllegroFlare/MultiMeshUV.hpp ]
   - symbol: AllegroFlare::MultiMeshUV
     headers: [ AllegroFlare/MultiMeshUV.hpp ]
+  - symbol: ALLEGRO_BITMAP*
+    headers: [ allegro5/allegro.h ]
  
 

--- a/quintessence/AllegroFlare/MultiMeshUVAtlas.q.yml
+++ b/quintessence/AllegroFlare/MultiMeshUVAtlas.q.yml
@@ -1,13 +1,6 @@
 properties:
 
 
-  - name: bitmap
-    type: ALLEGRO_BITMAP*
-    init_with: nullptr
-    constructor_arg: true
-    getter: true
-    setter: true
-
   - name: index
     type: std::map<int, AllegroFlare::MultiMeshUV>
     init_with: '{}'

--- a/quintessence/AllegroFlare/Network2/Message.q.yml
+++ b/quintessence/AllegroFlare/Network2/Message.q.yml
@@ -6,26 +6,26 @@ properties:
     const: true
     type: std::size_t
     init_with: 16
-    getter: true
+    constexpr: true
     
   - name: MAX_BODY_LENGTH
     static: true
     const: true
     type: std::size_t
     init_with: 512
-    getter: true
+    constexpr: true
 
   - name: MAGIC_HEADER_CHUNK
     static: true
     const: true
     type: std::string
-    init_with: '"AFNM"'
     getter: true
+    init_with: '"AFNM"'
 
   - name: data
     type: std::string
     getter: true
-    init_with: "16+512, ' '"
+    init_with: "HEADER_LENGTH+MAX_BODY_LENGTH, ' '"
 
   - name: body_length
     type: std::size_t
@@ -151,8 +151,7 @@ functions:
        // 4 chars, the first 4 characters of a hash. This hash is of the first 8 characters of the header
        // 4 chars, the first 4 characters of a hash of the whole body
 
-       char header[16 + 1] = ""; // eeks, here "16" is used rather than HEADER_LENGTH because constexpr is not
-                                 // supported in quintessence
+       char header[HEADER_LENGTH + 1] = "";
 
        std::string first_8 = MAGIC_HEADER_CHUNK + body_size_base62();
 
@@ -221,8 +220,6 @@ dependencies:
   - symbol: chat_message
     headers: [ AllegroFlare/Network2/inc/chat_message.hpp ]
   - symbol: char*
-    headers: [ ]
-  - symbol: char[16 + 512]
     headers: [ ]
   - symbol: std::size_t
     headers: [ cstddef ]

--- a/src/AllegroFlare/MultiMesh.cpp
+++ b/src/AllegroFlare/MultiMesh.cpp
@@ -106,19 +106,18 @@ void MultiMesh::append(float x, float y, float w, float h)
          error_message << "MultiMesh" << "::" << "append" << ": error: " << "guard \"initialized\" not met";
          throw std::runtime_error(error_message.str());
       }
-   // TODO
-   float u1 = 0.1f;
-   float v1 = 0.1f;
-   float u2 = 0.2f;
-   float v2 = 0.2f;
+   float u1 = 100.0f; // uvs using pixel coorindates; TODO: revise
+   float v1 = 100.0f;
+   float u2 = 200.0f;
+   float v2 = 200.0f;
    ALLEGRO_COLOR color{1, 1, 1, 1};
    ALLEGRO_VERTEX item_vertexes[6] = {
       ALLEGRO_VERTEX{x+0, y+0, 0, u1, v1, color},
-      ALLEGRO_VERTEX{x+0, y+h, 0, u1, v1, color},
-      ALLEGRO_VERTEX{x+w, y+0, 0, u1, v1, color},
-      ALLEGRO_VERTEX{x+w, y+0, 0, u1, v1, color},
-      ALLEGRO_VERTEX{x+0, y+h, 0, u1, v1, color},
-      ALLEGRO_VERTEX{x+w, y+h, 0, u1, v1, color},
+      ALLEGRO_VERTEX{x+0, y+h, 0, u1, v2, color},
+      ALLEGRO_VERTEX{x+w, y+0, 0, u2, v1, color},
+      ALLEGRO_VERTEX{x+w, y+0, 0, u2, v1, color},
+      ALLEGRO_VERTEX{x+0, y+h, 0, u1, v2, color},
+      ALLEGRO_VERTEX{x+w, y+h, 0, u2, v2, color},
    };
 
    ALLEGRO_VERTEX* start = (ALLEGRO_VERTEX*)al_lock_vertex_buffer(
@@ -163,7 +162,8 @@ void MultiMesh::render()
          throw std::runtime_error(error_message.str());
       }
    if (indexes_in_use == 0) return;
-   al_draw_indexed_buffer(vertex_buffer, texture, index_buffer, 0, indexes_in_use, ALLEGRO_PRIM_TRIANGLE_LIST);
+   al_draw_vertex_buffer(vertex_buffer, texture, 0, indexes_in_use, ALLEGRO_PRIM_TRIANGLE_LIST);
+   //al_draw_indexed_buffer(vertex_buffer, texture, index_buffer, 0, indexes_in_use, ALLEGRO_PRIM_TRIANGLE_LIST);
    return;
 }
 } // namespace AllegroFlare

--- a/src/AllegroFlare/MultiMesh.cpp
+++ b/src/AllegroFlare/MultiMesh.cpp
@@ -18,7 +18,7 @@ namespace AllegroFlare
 MultiMesh::MultiMesh()
    : vertex_buffer(nullptr)
    , texture(nullptr)
-   , indexes_in_use(0)
+   , vertices_in_use(0)
    , VERTEXES_PER_ITEM(6)
    , initialized(false)
 {
@@ -105,21 +105,22 @@ void MultiMesh::append(float x, float y, float w, float h, float u1, float v1, f
       ALLEGRO_VERTEX{x+w, y+h, 0, u2, v2, color},
    };
 
+   // lock the vertex buffer
    ALLEGRO_VERTEX* start = (ALLEGRO_VERTEX*)al_lock_vertex_buffer(
       vertex_buffer,
-      indexes_in_use,
+      vertices_in_use,
       VERTEXES_PER_ITEM,
       ALLEGRO_LOCK_WRITEONLY
    );
 
-   // fill 6 vertexes @ indexs
+   // fill 6 vertexes @ ind
    for (int i=0; i<6; i++) start[i] = item_vertexes[i];
 
    // unlock
    al_unlock_vertex_buffer(vertex_buffer);
 
-   // increase indexes_in_use by 6
-   indexes_in_use += 6;
+   // increase vertices_in_use by 6
+   vertices_in_use += 6;
    return;
 }
 
@@ -132,9 +133,9 @@ void MultiMesh::remove(int at_index)
          throw std::runtime_error(error_message.str());
       }
    // TODO
-   // lock @ index to indexes_in_use
+   // lock @ index to vertices_in_use
    // copy vertexes from end into removed position (if not already at end)
-   // reduce indexes_in_use by 6
+   // reduce vertices_in_use by 6
    // unlock
    return;
 }
@@ -147,8 +148,8 @@ void MultiMesh::render()
          error_message << "MultiMesh" << "::" << "render" << ": error: " << "guard \"initialized\" not met";
          throw std::runtime_error(error_message.str());
       }
-   if (indexes_in_use == 0) return;
-   al_draw_vertex_buffer(vertex_buffer, texture, 0, indexes_in_use, ALLEGRO_PRIM_TRIANGLE_LIST);
+   if (vertices_in_use == 0) return;
+   al_draw_vertex_buffer(vertex_buffer, texture, 0, vertices_in_use, ALLEGRO_PRIM_TRIANGLE_LIST);
    return;
 }
 } // namespace AllegroFlare

--- a/src/AllegroFlare/MultiMesh.cpp
+++ b/src/AllegroFlare/MultiMesh.cpp
@@ -5,6 +5,10 @@
 #include <sstream>
 #include <stdexcept>
 #include <sstream>
+#include <stdexcept>
+#include <sstream>
+#include <stdexcept>
+#include <sstream>
 
 
 namespace AllegroFlare
@@ -14,6 +18,7 @@ namespace AllegroFlare
 MultiMesh::MultiMesh()
    : vertex_buffer(nullptr)
    , index_buffer(nullptr)
+   , texture(nullptr)
    , indexes_in_use(0)
    , initialized(false)
 {
@@ -22,6 +27,18 @@ MultiMesh::MultiMesh()
 
 MultiMesh::~MultiMesh()
 {
+}
+
+
+void MultiMesh::set_texture(ALLEGRO_BITMAP* texture)
+{
+   this->texture = texture;
+}
+
+
+ALLEGRO_BITMAP* MultiMesh::get_texture() const
+{
+   return texture;
 }
 
 
@@ -82,13 +99,33 @@ void MultiMesh::initialize()
 
 void MultiMesh::append(float x, float y, float w, float h)
 {
+   if (!(initialized))
+      {
+         std::stringstream error_message;
+         error_message << "MultiMesh" << "::" << "append" << ": error: " << "guard \"initialized\" not met";
+         throw std::runtime_error(error_message.str());
+      }
    // TODO
+   // lock
+   // fill 6 vertexes @ indexs
+   // unlock
+   // increase indexes_in_use by 6
    return;
 }
 
 void MultiMesh::remove(int at_index)
 {
+   if (!(initialized))
+      {
+         std::stringstream error_message;
+         error_message << "MultiMesh" << "::" << "remove" << ": error: " << "guard \"initialized\" not met";
+         throw std::runtime_error(error_message.str());
+      }
    // TODO
+   // lock @ index to indexes_in_use
+   // copy vertexes from end into removed position (if not already at end)
+   // reduce indexes_in_use by 6
+   // unlock
    return;
 }
 
@@ -100,9 +137,8 @@ void MultiMesh::render()
          error_message << "MultiMesh" << "::" << "render" << ": error: " << "guard \"initialized\" not met";
          throw std::runtime_error(error_message.str());
       }
-   //int al_draw_indexed_buffer(ALLEGRO_VERTEX_BUFFER* vertex_buffer,
-      //ALLEGRO_BITMAP* texture, ALLEGRO_INDEX_BUFFER* index_buffer,
-      //int start, int end, int type)
+   if (indexes_in_use == 0) return;
+   al_draw_indexed_buffer(vertex_buffer, texture, index_buffer, 0, indexes_in_use, ALLEGRO_PRIM_TRIANGLE_LIST);
    return;
 }
 } // namespace AllegroFlare

--- a/src/AllegroFlare/MultiMesh.cpp
+++ b/src/AllegroFlare/MultiMesh.cpp
@@ -9,6 +9,8 @@
 #include <sstream>
 #include <stdexcept>
 #include <sstream>
+#include <stdexcept>
+#include <sstream>
 
 
 namespace AllegroFlare
@@ -21,6 +23,7 @@ MultiMesh::MultiMesh()
    , num_items(50)
    , vertices_in_use(0)
    , VERTEXES_PER_ITEM(6)
+   , atlas()
    , initialized(false)
 {
 }
@@ -42,6 +45,18 @@ ALLEGRO_BITMAP* MultiMesh::get_texture() const
    return texture;
 }
 
+
+void MultiMesh::set_atlas(AllegroFlare::MultiMeshUVAtlas atlas)
+{
+   if (!((!initialized)))
+      {
+         std::stringstream error_message;
+         error_message << "MultiMesh" << "::" << "set_atlas" << ": error: " << "guard \"(!initialized)\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   this->atlas = atlas;
+   return;
+}
 
 void MultiMesh::initialize()
 {
@@ -84,6 +99,22 @@ void MultiMesh::initialize()
    );
 
    initialized = true;
+   return;
+}
+
+void MultiMesh::append_item_from_atlas_index(int atlas_item_index_num, float x, float y)
+{
+   AllegroFlare::MultiMeshUV atlas_item = atlas.get(atlas_item_index_num);
+   append(
+      x,
+      y,
+      atlas_item.infer_width(),
+      atlas_item.infer_height(),
+      atlas_item.get_u1(),
+      atlas_item.get_v1(),
+      atlas_item.get_u2(),
+      atlas_item.get_v2()
+   );
    return;
 }
 

--- a/src/AllegroFlare/MultiMesh.cpp
+++ b/src/AllegroFlare/MultiMesh.cpp
@@ -44,7 +44,50 @@ void MultiMesh::initialize()
          error_message << "MultiMesh" << "::" << "initialize" << ": error: " << "guard \"al_is_primitives_addon_initialized()\" not met";
          throw std::runtime_error(error_message.str());
       }
+   int num_elements = 50;
+   int num_vertices = num_elements * 6;
+
+   // create the vertex declaration
+   ALLEGRO_VERTEX_ELEMENT elems[] = {
+      {ALLEGRO_PRIM_POSITION, ALLEGRO_PRIM_FLOAT_3, offsetof(ALLEGRO_VERTEX, x)},
+      {ALLEGRO_PRIM_TEX_COORD_PIXEL, ALLEGRO_PRIM_FLOAT_2, offsetof(ALLEGRO_VERTEX, u)},
+      {ALLEGRO_PRIM_COLOR_ATTR, 0, offsetof(ALLEGRO_VERTEX, color)},
+      {0, 0, 0}
+   };
+   ALLEGRO_VERTEX_DECL* decl = al_create_vertex_decl(elems, sizeof(ALLEGRO_VERTEX));
+
+   // vertex buffer, data will be uninitialized
+   const void* initial_data_vb = nullptr;
+   vertex_buffer = al_create_vertex_buffer(
+      decl,
+      initial_data_vb,
+      num_vertices,
+      ALLEGRO_PRIM_BUFFER_READWRITE
+   );
+
+   // index buffer, data will be uninitialized
+   // size of the buffer is 2, which is a short, limiting the size to a certain amount (TODO, figure out amount)
+   const void* initial_data_ib = nullptr;
+   index_buffer = al_create_index_buffer(
+      sizeof(short),
+      initial_data_ib,
+      num_vertices,
+      ALLEGRO_PRIM_BUFFER_READWRITE
+   );
+
    initialized = true;
+   return;
+}
+
+void MultiMesh::append()
+{
+   // TODO
+   return;
+}
+
+void MultiMesh::remove()
+{
+   // TODO
    return;
 }
 
@@ -56,6 +99,9 @@ void MultiMesh::render()
          error_message << "MultiMesh" << "::" << "render" << ": error: " << "guard \"initialized\" not met";
          throw std::runtime_error(error_message.str());
       }
+   //int al_draw_indexed_buffer(ALLEGRO_VERTEX_BUFFER* vertex_buffer,
+      //ALLEGRO_BITMAP* texture, ALLEGRO_INDEX_BUFFER* index_buffer,
+      //int start, int end, int type)
    return;
 }
 } // namespace AllegroFlare

--- a/src/AllegroFlare/MultiMesh.cpp
+++ b/src/AllegroFlare/MultiMesh.cpp
@@ -102,10 +102,10 @@ void MultiMesh::initialize()
    return;
 }
 
-void MultiMesh::append_item_from_atlas_index(int atlas_item_index_num, float x, float y)
+void MultiMesh::append(int atlas_item_index_num, float x, float y)
 {
    AllegroFlare::MultiMeshUV atlas_item = atlas.get(atlas_item_index_num);
-   append(
+   append_raw(
       x,
       y,
       atlas_item.infer_width(),
@@ -118,12 +118,12 @@ void MultiMesh::append_item_from_atlas_index(int atlas_item_index_num, float x, 
    return;
 }
 
-void MultiMesh::append(float x, float y, float w, float h, float u1, float v1, float u2, float v2)
+void MultiMesh::append_raw(float x, float y, float w, float h, float u1, float v1, float u2, float v2)
 {
    if (!(initialized))
       {
          std::stringstream error_message;
-         error_message << "MultiMesh" << "::" << "append" << ": error: " << "guard \"initialized\" not met";
+         error_message << "MultiMesh" << "::" << "append_raw" << ": error: " << "guard \"initialized\" not met";
          throw std::runtime_error(error_message.str());
       }
    ALLEGRO_COLOR color{1, 1, 1, 1};

--- a/src/AllegroFlare/MultiMesh.cpp
+++ b/src/AllegroFlare/MultiMesh.cpp
@@ -17,7 +17,6 @@ namespace AllegroFlare
 
 MultiMesh::MultiMesh()
    : vertex_buffer(nullptr)
-   , index_buffer(nullptr)
    , texture(nullptr)
    , indexes_in_use(0)
    , VERTEXES_PER_ITEM(6)
@@ -80,16 +79,6 @@ void MultiMesh::initialize()
    vertex_buffer = al_create_vertex_buffer(
       decl,
       initial_data_vb,
-      num_vertices,
-      ALLEGRO_PRIM_BUFFER_READWRITE
-   );
-
-   // index buffer, data will be uninitialized
-   // size of the buffer is 2, which is a short, limiting the size to a certain amount (TODO, figure out amount)
-   const void* initial_data_ib = nullptr;
-   index_buffer = al_create_index_buffer(
-      sizeof(short),
-      initial_data_ib,
       num_vertices,
       ALLEGRO_PRIM_BUFFER_READWRITE
    );
@@ -160,7 +149,6 @@ void MultiMesh::render()
       }
    if (indexes_in_use == 0) return;
    al_draw_vertex_buffer(vertex_buffer, texture, 0, indexes_in_use, ALLEGRO_PRIM_TRIANGLE_LIST);
-   //al_draw_indexed_buffer(vertex_buffer, texture, index_buffer, 0, indexes_in_use, ALLEGRO_PRIM_TRIANGLE_LIST);
    return;
 }
 } // namespace AllegroFlare

--- a/src/AllegroFlare/MultiMesh.cpp
+++ b/src/AllegroFlare/MultiMesh.cpp
@@ -19,7 +19,7 @@ namespace AllegroFlare
 {
 
 
-MultiMesh::MultiMesh(int num_items)
+MultiMesh::MultiMesh(std::size_t num_items)
    : num_items(num_items)
    , vertex_buffer(nullptr)
    , vertex_decl(nullptr)
@@ -43,7 +43,7 @@ void MultiMesh::set_texture(ALLEGRO_BITMAP* texture)
 }
 
 
-int MultiMesh::get_num_items() const
+std::size_t MultiMesh::get_num_items() const
 {
    return num_items;
 }
@@ -67,7 +67,7 @@ void MultiMesh::set_atlas(AllegroFlare::MultiMeshUVAtlas atlas)
    return;
 }
 
-void MultiMesh::set_num_items(int num_items)
+void MultiMesh::set_num_items(std::size_t num_items)
 {
    if (!((!initialized)))
       {

--- a/src/AllegroFlare/MultiMesh.cpp
+++ b/src/AllegroFlare/MultiMesh.cpp
@@ -14,6 +14,7 @@ namespace AllegroFlare
 MultiMesh::MultiMesh()
    : vertex_buffer(nullptr)
    , index_buffer(nullptr)
+   , indexes_in_use(0)
    , initialized(false)
 {
 }
@@ -79,13 +80,13 @@ void MultiMesh::initialize()
    return;
 }
 
-void MultiMesh::append()
+void MultiMesh::append(float x, float y, float w, float h)
 {
    // TODO
    return;
 }
 
-void MultiMesh::remove()
+void MultiMesh::remove(int at_index)
 {
    // TODO
    return;

--- a/src/AllegroFlare/MultiMesh.cpp
+++ b/src/AllegroFlare/MultiMesh.cpp
@@ -11,16 +11,19 @@
 #include <sstream>
 #include <stdexcept>
 #include <sstream>
+#include <stdexcept>
+#include <sstream>
 
 
 namespace AllegroFlare
 {
 
 
-MultiMesh::MultiMesh()
-   : vertex_buffer(nullptr)
+MultiMesh::MultiMesh(int num_items)
+   : num_items(num_items)
+   , vertex_buffer(nullptr)
+   , vertex_decl(nullptr)
    , texture(nullptr)
-   , num_items(50)
    , vertices_in_use(0)
    , VERTEXES_PER_ITEM(6)
    , atlas()
@@ -40,6 +43,12 @@ void MultiMesh::set_texture(ALLEGRO_BITMAP* texture)
 }
 
 
+int MultiMesh::get_num_items() const
+{
+   return num_items;
+}
+
+
 ALLEGRO_BITMAP* MultiMesh::get_texture() const
 {
    return texture;
@@ -55,6 +64,18 @@ void MultiMesh::set_atlas(AllegroFlare::MultiMeshUVAtlas atlas)
          throw std::runtime_error(error_message.str());
       }
    this->atlas = atlas;
+   return;
+}
+
+void MultiMesh::set_num_items(int num_items)
+{
+   if (!((!initialized)))
+      {
+         std::stringstream error_message;
+         error_message << "MultiMesh" << "::" << "set_num_items" << ": error: " << "guard \"(!initialized)\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   this->num_items = num_items;
    return;
 }
 
@@ -87,12 +108,12 @@ void MultiMesh::initialize()
       {ALLEGRO_PRIM_COLOR_ATTR, 0, offsetof(ALLEGRO_VERTEX, color)},
       {0, 0, 0}
    };
-   ALLEGRO_VERTEX_DECL* decl = al_create_vertex_decl(elems, sizeof(ALLEGRO_VERTEX));
+   vertex_decl = al_create_vertex_decl(elems, sizeof(ALLEGRO_VERTEX));
 
    // vertex buffer, data will be uninitialized
    const void* initial_data_vb = nullptr;
    vertex_buffer = al_create_vertex_buffer(
-      decl,
+      vertex_decl,
       initial_data_vb,
       num_vertices,
       ALLEGRO_PRIM_BUFFER_READWRITE

--- a/src/AllegroFlare/MultiMesh.cpp
+++ b/src/AllegroFlare/MultiMesh.cpp
@@ -20,6 +20,7 @@ MultiMesh::MultiMesh()
    , index_buffer(nullptr)
    , texture(nullptr)
    , indexes_in_use(0)
+   , VERTEXES_PER_ITEM(6)
    , initialized(false)
 {
 }
@@ -62,8 +63,8 @@ void MultiMesh::initialize()
          error_message << "MultiMesh" << "::" << "initialize" << ": error: " << "guard \"al_is_primitives_addon_initialized()\" not met";
          throw std::runtime_error(error_message.str());
       }
-   int num_elements = 50;
-   int num_vertices = num_elements * 6;
+   int num_items = 50;
+   int num_vertices = num_items * VERTEXES_PER_ITEM;
 
    // create the vertex declaration
    ALLEGRO_VERTEX_ELEMENT elems[] = {
@@ -106,10 +107,34 @@ void MultiMesh::append(float x, float y, float w, float h)
          throw std::runtime_error(error_message.str());
       }
    // TODO
-   // lock
+   float u1 = 0.1f;
+   float v1 = 0.1f;
+   float u2 = 0.2f;
+   float v2 = 0.2f;
+   ALLEGRO_COLOR color{1, 1, 1, 1};
+   ALLEGRO_VERTEX item_vertexes[6] = {
+      ALLEGRO_VERTEX{x+0, y+0, 0, u1, v1, color},
+      ALLEGRO_VERTEX{x+0, y+h, 0, u1, v1, color},
+      ALLEGRO_VERTEX{x+w, y+0, 0, u1, v1, color},
+      ALLEGRO_VERTEX{x+w, y+0, 0, u1, v1, color},
+      ALLEGRO_VERTEX{x+0, y+h, 0, u1, v1, color},
+      ALLEGRO_VERTEX{x+w, y+h, 0, u1, v1, color},
+   };
+
+   ALLEGRO_VERTEX* start = (ALLEGRO_VERTEX*)al_lock_vertex_buffer(
+      vertex_buffer,
+      indexes_in_use,
+      VERTEXES_PER_ITEM,
+      ALLEGRO_LOCK_WRITEONLY
+   );
+
    // fill 6 vertexes @ indexs
+   for (int i=0; i<6; i++) start[i] = item_vertexes[i];
+
    // unlock
+   al_unlock_vertex_buffer(vertex_buffer);
    // increase indexes_in_use by 6
+   indexes_in_use += 6;
    return;
 }
 

--- a/src/AllegroFlare/MultiMesh.cpp
+++ b/src/AllegroFlare/MultiMesh.cpp
@@ -1,0 +1,63 @@
+
+
+#include <AllegroFlare/MultiMesh.hpp>
+#include <stdexcept>
+#include <sstream>
+#include <stdexcept>
+#include <sstream>
+
+
+namespace AllegroFlare
+{
+
+
+MultiMesh::MultiMesh()
+   : vertex_buffer(nullptr)
+   , index_buffer(nullptr)
+   , initialized(false)
+{
+}
+
+
+MultiMesh::~MultiMesh()
+{
+}
+
+
+void MultiMesh::initialize()
+{
+   if (!((!initialized)))
+      {
+         std::stringstream error_message;
+         error_message << "MultiMesh" << "::" << "initialize" << ": error: " << "guard \"(!initialized)\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   if (!(al_is_system_installed()))
+      {
+         std::stringstream error_message;
+         error_message << "MultiMesh" << "::" << "initialize" << ": error: " << "guard \"al_is_system_installed()\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   if (!(al_is_primitives_addon_initialized()))
+      {
+         std::stringstream error_message;
+         error_message << "MultiMesh" << "::" << "initialize" << ": error: " << "guard \"al_is_primitives_addon_initialized()\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   initialized = true;
+   return;
+}
+
+void MultiMesh::render()
+{
+   if (!(initialized))
+      {
+         std::stringstream error_message;
+         error_message << "MultiMesh" << "::" << "render" << ": error: " << "guard \"initialized\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   return;
+}
+} // namespace AllegroFlare
+
+

--- a/src/AllegroFlare/MultiMesh.cpp
+++ b/src/AllegroFlare/MultiMesh.cpp
@@ -98,7 +98,7 @@ void MultiMesh::initialize()
    return;
 }
 
-void MultiMesh::append(float x, float y, float w, float h)
+void MultiMesh::append(float x, float y, float w, float h, float u1, float v1, float u2, float v2)
 {
    if (!(initialized))
       {
@@ -106,10 +106,6 @@ void MultiMesh::append(float x, float y, float w, float h)
          error_message << "MultiMesh" << "::" << "append" << ": error: " << "guard \"initialized\" not met";
          throw std::runtime_error(error_message.str());
       }
-   float u1 = 100.0f; // uvs using pixel coorindates; TODO: revise
-   float v1 = 100.0f;
-   float u2 = 200.0f;
-   float v2 = 200.0f;
    ALLEGRO_COLOR color{1, 1, 1, 1};
    ALLEGRO_VERTEX item_vertexes[6] = {
       ALLEGRO_VERTEX{x+0, y+0, 0, u1, v1, color},
@@ -132,6 +128,7 @@ void MultiMesh::append(float x, float y, float w, float h)
 
    // unlock
    al_unlock_vertex_buffer(vertex_buffer);
+
    // increase indexes_in_use by 6
    indexes_in_use += 6;
    return;

--- a/src/AllegroFlare/MultiMesh.cpp
+++ b/src/AllegroFlare/MultiMesh.cpp
@@ -124,7 +124,7 @@ void MultiMesh::append(float x, float y, float w, float h, float u1, float v1, f
    return;
 }
 
-void MultiMesh::remove(int at_index)
+void MultiMesh::remove(int item_index)
 {
    if (!(initialized))
       {

--- a/src/AllegroFlare/MultiMesh.cpp
+++ b/src/AllegroFlare/MultiMesh.cpp
@@ -124,7 +124,7 @@ void MultiMesh::append(float x, float y, float w, float h, float u1, float v1, f
    return;
 }
 
-void MultiMesh::remove(int item_index)
+int MultiMesh::remove(int item_index)
 {
    if (!(initialized))
       {
@@ -136,6 +136,7 @@ void MultiMesh::remove(int item_index)
    // validate position exists, does not overflow, etc
    int item_start_index = item_index * VERTEXES_PER_ITEM;
    int length = vertices_in_use - item_start_index; // all the way to the end of vertices_in_use
+   bool removed_vertex_is_at_end = (item_start_index == vertices_in_use-VERTEXES_PER_ITEM);
 
    // lock @ index to vertices_in_use
    ALLEGRO_VERTEX* start = (ALLEGRO_VERTEX*)al_lock_vertex_buffer(
@@ -146,14 +147,15 @@ void MultiMesh::remove(int item_index)
    );
 
    // copy vertexes from end (end-6) into removed position (if not already at end)
-   for (int i=0; i<6; i++) start[i] = start[i + length-6];
+   if (!removed_vertex_is_at_end) for (int i=0; i<6; i++) start[i] = start[i + length-VERTEXES_PER_ITEM];
 
    // unlock
    al_unlock_vertex_buffer(vertex_buffer);
 
    // reduce vertices_in_use by 6
    vertices_in_use -= 6;
-   return;
+   if (removed_vertex_is_at_end) return item_index;
+   return vertices_in_use / VERTEXES_PER_ITEM;
 }
 
 void MultiMesh::render()

--- a/src/AllegroFlare/MultiMesh.cpp
+++ b/src/AllegroFlare/MultiMesh.cpp
@@ -163,8 +163,7 @@ int MultiMesh::remove(int item_index)
          error_message << "MultiMesh" << "::" << "remove" << ": error: " << "guard \"initialized\" not met";
          throw std::runtime_error(error_message.str());
       }
-   // TODO
-   // validate position exists, does not overflow, etc
+   // TODO: validate position exists, does not overflow, etc
    int item_start_index = item_index * VERTEXES_PER_ITEM;
    int length = vertices_in_use - item_start_index; // all the way to the end of vertices_in_use
    bool removed_vertex_is_at_end = (item_start_index == vertices_in_use-VERTEXES_PER_ITEM);

--- a/src/AllegroFlare/MultiMeshUV.cpp
+++ b/src/AllegroFlare/MultiMeshUV.cpp
@@ -1,0 +1,75 @@
+
+
+#include <AllegroFlare/MultiMeshUV.hpp>
+
+
+
+namespace AllegroFlare
+{
+
+
+MultiMeshUV::MultiMeshUV(float u1, float v1, float u2, float v2)
+   : u1(u1)
+   , v1(v1)
+   , u2(u2)
+   , v2(v2)
+{
+}
+
+
+MultiMeshUV::~MultiMeshUV()
+{
+}
+
+
+void MultiMeshUV::set_u1(float u1)
+{
+   this->u1 = u1;
+}
+
+
+void MultiMeshUV::set_v1(float v1)
+{
+   this->v1 = v1;
+}
+
+
+void MultiMeshUV::set_u2(float u2)
+{
+   this->u2 = u2;
+}
+
+
+void MultiMeshUV::set_v2(float v2)
+{
+   this->v2 = v2;
+}
+
+
+float MultiMeshUV::get_u1() const
+{
+   return u1;
+}
+
+
+float MultiMeshUV::get_v1() const
+{
+   return v1;
+}
+
+
+float MultiMeshUV::get_u2() const
+{
+   return u2;
+}
+
+
+float MultiMeshUV::get_v2() const
+{
+   return v2;
+}
+
+
+} // namespace AllegroFlare
+
+

--- a/src/AllegroFlare/MultiMeshUV.cpp
+++ b/src/AllegroFlare/MultiMeshUV.cpp
@@ -70,6 +70,15 @@ float MultiMeshUV::get_v2() const
 }
 
 
+float MultiMeshUV::infer_width()
+{
+   return u2-u1;
+}
+
+float MultiMeshUV::infer_height()
+{
+   return v2-v1;
+}
 } // namespace AllegroFlare
 
 

--- a/src/AllegroFlare/MultiMeshUVAtlas.cpp
+++ b/src/AllegroFlare/MultiMeshUVAtlas.cpp
@@ -9,9 +9,8 @@ namespace AllegroFlare
 {
 
 
-MultiMeshUVAtlas::MultiMeshUVAtlas(ALLEGRO_BITMAP* bitmap, std::map<int, AllegroFlare::MultiMeshUV> index)
-   : bitmap(bitmap)
-   , index(index)
+MultiMeshUVAtlas::MultiMeshUVAtlas(std::map<int, AllegroFlare::MultiMeshUV> index)
+   : index(index)
 {
 }
 
@@ -21,21 +20,9 @@ MultiMeshUVAtlas::~MultiMeshUVAtlas()
 }
 
 
-void MultiMeshUVAtlas::set_bitmap(ALLEGRO_BITMAP* bitmap)
-{
-   this->bitmap = bitmap;
-}
-
-
 void MultiMeshUVAtlas::set_index(std::map<int, AllegroFlare::MultiMeshUV> index)
 {
    this->index = index;
-}
-
-
-ALLEGRO_BITMAP* MultiMeshUVAtlas::get_bitmap() const
-{
-   return bitmap;
 }
 
 

--- a/src/AllegroFlare/MultiMeshUVAtlas.cpp
+++ b/src/AllegroFlare/MultiMeshUVAtlas.cpp
@@ -1,7 +1,8 @@
 
 
 #include <AllegroFlare/MultiMeshUVAtlas.hpp>
-
+#include <sstream>
+#include <iostream>
 
 
 namespace AllegroFlare
@@ -31,6 +32,29 @@ std::map<int, AllegroFlare::MultiMeshUV> MultiMeshUVAtlas::get_index() const
 }
 
 
+void MultiMeshUVAtlas::add(int index_num, float u1, float v1, float u2, float v2)
+{
+   index[index_num] = AllegroFlare::MultiMeshUV(u1, v1, u2, v2);
+   return;
+}
+
+bool MultiMeshUVAtlas::exists(int index_num)
+{
+   return (index.count(index_num) == 1);
+}
+
+AllegroFlare::MultiMeshUV MultiMeshUVAtlas::get(int index_num)
+{
+   if (!exists(index_num))
+   {
+      std::stringstream error_message;
+      error_message << "AllegroFlare::MultiMeshUVAtlas::get error: "
+                    << "Item does not exist at index_num " << index_num << ". Returning a default MultiMeshUV.";
+      std::cout << error_message.str() << std::endl;
+      return AllegroFlare::MultiMeshUV();
+   }
+   return index[index_num];
+}
 } // namespace AllegroFlare
 
 

--- a/src/AllegroFlare/MultiMeshUVAtlas.cpp
+++ b/src/AllegroFlare/MultiMeshUVAtlas.cpp
@@ -9,8 +9,9 @@ namespace AllegroFlare
 {
 
 
-MultiMeshUVAtlas::MultiMeshUVAtlas(std::map<int, AllegroFlare::MultiMeshUV> index)
-   : index(index)
+MultiMeshUVAtlas::MultiMeshUVAtlas(ALLEGRO_BITMAP* bitmap, std::map<int, AllegroFlare::MultiMeshUV> index)
+   : bitmap(bitmap)
+   , index(index)
 {
 }
 
@@ -20,9 +21,21 @@ MultiMeshUVAtlas::~MultiMeshUVAtlas()
 }
 
 
+void MultiMeshUVAtlas::set_bitmap(ALLEGRO_BITMAP* bitmap)
+{
+   this->bitmap = bitmap;
+}
+
+
 void MultiMeshUVAtlas::set_index(std::map<int, AllegroFlare::MultiMeshUV> index)
 {
    this->index = index;
+}
+
+
+ALLEGRO_BITMAP* MultiMeshUVAtlas::get_bitmap() const
+{
+   return bitmap;
 }
 
 

--- a/src/AllegroFlare/MultiMeshUVAtlas.cpp
+++ b/src/AllegroFlare/MultiMeshUVAtlas.cpp
@@ -1,0 +1,36 @@
+
+
+#include <AllegroFlare/MultiMeshUVAtlas.hpp>
+
+
+
+namespace AllegroFlare
+{
+
+
+MultiMeshUVAtlas::MultiMeshUVAtlas(std::map<int, AllegroFlare::MultiMeshUV> index)
+   : index(index)
+{
+}
+
+
+MultiMeshUVAtlas::~MultiMeshUVAtlas()
+{
+}
+
+
+void MultiMeshUVAtlas::set_index(std::map<int, AllegroFlare::MultiMeshUV> index)
+{
+   this->index = index;
+}
+
+
+std::map<int, AllegroFlare::MultiMeshUV> MultiMeshUVAtlas::get_index() const
+{
+   return index;
+}
+
+
+} // namespace AllegroFlare
+
+

--- a/src/AllegroFlare/Network2/Message.cpp
+++ b/src/AllegroFlare/Network2/Message.cpp
@@ -18,17 +18,11 @@ namespace Network2
 {
 
 
-std::size_t Message::HEADER_LENGTH = 16;
-
-
-std::size_t Message::MAX_BODY_LENGTH = 512;
-
-
 std::string Message::MAGIC_HEADER_CHUNK = "AFNM";
 
 
 Message::Message()
-   : data(16+512, ' ')
+   : data(HEADER_LENGTH+MAX_BODY_LENGTH, ' ')
    , body_length(0)
 {
 }
@@ -36,18 +30,6 @@ Message::Message()
 
 Message::~Message()
 {
-}
-
-
-std::size_t Message::get_HEADER_LENGTH()
-{
-   return HEADER_LENGTH;
-}
-
-
-std::size_t Message::get_MAX_BODY_LENGTH()
-{
-   return MAX_BODY_LENGTH;
 }
 
 
@@ -175,8 +157,7 @@ void Message::encode_header()
    // 4 chars, the first 4 characters of a hash. This hash is of the first 8 characters of the header
    // 4 chars, the first 4 characters of a hash of the whole body
 
-   char header[16 + 1] = ""; // eeks, here "16" is used rather than HEADER_LENGTH because constexpr is not
-                             // supported in quintessence
+   char header[HEADER_LENGTH + 1] = "";
 
    std::string first_8 = MAGIC_HEADER_CHUNK + body_size_base62();
 

--- a/tests/AllegroFlare/MultiMeshTest.cpp
+++ b/tests/AllegroFlare/MultiMeshTest.cpp
@@ -58,3 +58,21 @@ TEST_F(AllegroFlare_MultiMeshTestWithAllegroRenderingFixture, CAPTURE__render__w
 }
 
 
+TEST_F(AllegroFlare_MultiMeshTestWithAllegroRenderingFixture, CAPTURE__remove__will_remove_the_item_from_the_mesh)
+{
+   ALLEGRO_BITMAP *texture = get_bitmap_bin_ref()["uv.png"];
+   AllegroFlare::MultiMesh multi_mesh;
+   multi_mesh.set_texture(texture);
+   multi_mesh.initialize();
+
+   multi_mesh.append(300, 200, 100, 100);
+   multi_mesh.append(600, 300, 100, 100);
+   multi_mesh.append(1000, 500, 100, 100);
+
+   multi_mesh.remove(1);
+
+   multi_mesh.render();
+   al_flip_display();
+}
+
+

--- a/tests/AllegroFlare/MultiMeshTest.cpp
+++ b/tests/AllegroFlare/MultiMeshTest.cpp
@@ -50,11 +50,25 @@ TEST_F(AllegroFlare_MultiMeshTestWithAllegroRenderingFixture, CAPTURE__render__w
    multi_mesh.set_texture(texture);
    multi_mesh.initialize();
 
-   multi_mesh.append(300, 200, 100, 100);
-   multi_mesh.append(600, 300, 100, 100);
+   multi_mesh.append_raw(300, 200, 100, 100, 100, 100, 200, 200);
+   multi_mesh.append_raw(600, 300, 100, 100, 100, 100, 200, 200);
 
    multi_mesh.render();
    al_flip_display();
+}
+
+
+TEST_F(AllegroFlare_MultiMeshTestWithAllegroRenderingFixture, append_raw__will_append_an_item_to_the_mesh)
+{
+   ALLEGRO_BITMAP *texture = get_bitmap_bin_ref()["uv.png"];
+   AllegroFlare::MultiMesh multi_mesh;
+   multi_mesh.set_texture(texture);
+   multi_mesh.initialize();
+
+   multi_mesh.append_raw(300, 200, 100, 100, 100, 100, 200, 200);
+   multi_mesh.append_raw(600, 300, 100, 100, 100, 100, 200, 200);
+
+   // TODO: assert
 }
 
 
@@ -65,9 +79,9 @@ TEST_F(AllegroFlare_MultiMeshTestWithAllegroRenderingFixture, CAPTURE__remove__w
    multi_mesh.set_texture(texture);
    multi_mesh.initialize();
 
-   multi_mesh.append(300, 200, 100, 100);
-   multi_mesh.append(600, 300, 100, 100);
-   multi_mesh.append(1000, 500, 100, 100);
+   multi_mesh.append_raw(300, 200, 100, 100, 100, 100, 200, 200);
+   multi_mesh.append_raw(600, 300, 100, 100, 100, 100, 200, 200);
+   multi_mesh.append_raw(1000, 500, 100, 100, 100, 100, 200, 200);
 
    multi_mesh.remove(1);
 
@@ -84,19 +98,41 @@ TEST_F(AllegroFlare_MultiMeshTestWithAllegroRenderingFixture,
    multi_mesh.set_texture(texture);
    multi_mesh.initialize();
 
-   multi_mesh.append(300, 200, 100, 100);
-   multi_mesh.append(600, 300, 100, 100);
-   multi_mesh.append(1000, 500, 100, 100);
+   multi_mesh.append_raw(300, 200, 100, 100, 100, 100, 200, 200);
+   multi_mesh.append_raw(600, 300, 100, 100, 100, 100, 200, 200);
+   multi_mesh.append_raw(1000, 500, 100, 100, 100, 100, 200, 200);
 
    int moved_index = multi_mesh.remove(1);
    EXPECT_EQ(2, moved_index);
 }
 
 
-TEST_F(AllegroFlare_MultiMeshTestWithAllegroRenderingFixture,
-   append_item_from_atlas_index__will_use_the_atlas_data_to_build_uv)
+TEST_F(AllegroFlare_MultiMeshTestWithAllegroRenderingFixture, append__before_initialized__will_throw_an_error)
 {
-   //TODO: test atlas features
+   // TODO
+}
+
+
+TEST_F(AllegroFlare_MultiMeshTestWithAllegroRenderingFixture,
+   CAPTURE__append__will_use_the_atlas_data_to_build_uv)
+{
+   ALLEGRO_BITMAP *texture = get_bitmap_bin_ref()["uv.png"];
+   AllegroFlare::MultiMeshUVAtlas atlas({
+      { 0, {    0,    0,  100,  100 } },
+      { 1, {  100,    0,  200,  100 } },
+      { 2, {  200,    0,  300,  100 } },
+      { 3, {  300,    0,  400,  100 } },
+   });
+   AllegroFlare::MultiMesh multi_mesh;
+   multi_mesh.set_texture(texture);
+   multi_mesh.set_atlas(atlas);
+   multi_mesh.initialize();
+
+   multi_mesh.append(1, 300, 600);
+   multi_mesh.append(2, 700, 550);
+   
+   multi_mesh.render();
+   al_flip_display();
 }
 
 

--- a/tests/AllegroFlare/MultiMeshTest.cpp
+++ b/tests/AllegroFlare/MultiMeshTest.cpp
@@ -45,8 +45,14 @@ TEST_F(AllegroFlare_MultiMeshTestWithAllegroRenderingFixture, render__will_not_b
 
 TEST_F(AllegroFlare_MultiMeshTestWithAllegroRenderingFixture, CAPTURE__render__will_render_the_mesh)
 {
+   ALLEGRO_BITMAP *texture = get_bitmap_bin_ref()["uv.png"];
    AllegroFlare::MultiMesh multi_mesh;
+   multi_mesh.set_texture(texture);
    multi_mesh.initialize();
+
+   multi_mesh.append(300, 200, 100, 100);
+   multi_mesh.append(600, 300, 100, 100);
+
    multi_mesh.render();
    al_flip_display();
 }

--- a/tests/AllegroFlare/MultiMeshTest.cpp
+++ b/tests/AllegroFlare/MultiMeshTest.cpp
@@ -93,3 +93,10 @@ TEST_F(AllegroFlare_MultiMeshTestWithAllegroRenderingFixture,
 }
 
 
+TEST_F(AllegroFlare_MultiMeshTestWithAllegroRenderingFixture,
+   append_item_from_atlas_index__will_use_the_atlas_data_to_build_uv)
+{
+   //TODO: test atlas features
+}
+
+

--- a/tests/AllegroFlare/MultiMeshTest.cpp
+++ b/tests/AllegroFlare/MultiMeshTest.cpp
@@ -1,0 +1,54 @@
+
+#include <gtest/gtest.h>
+
+#define ASSERT_THROW_WITH_MESSAGE(code, raised_exception_type, expected_exception_message) \
+   try { code; FAIL() << "Expected " # raised_exception_type; } \
+   catch ( raised_exception_type const &err ) { ASSERT_EQ(std::string(expected_exception_message), err.what()); } \
+   catch (...) { FAIL() << "Expected " # raised_exception_type; }
+
+#include <AllegroFlare/Testing/WithAllegroRenderingFixture.hpp>
+
+
+class AllegroFlare_MultiMeshTest : public ::testing::Test
+{};
+
+class AllegroFlare_MultiMeshTestWithAllegroRenderingFixture
+   : public AllegroFlare::Testing::WithAllegroRenderingFixture
+{};
+
+
+#include <AllegroFlare/MultiMesh.hpp>
+
+
+TEST_F(AllegroFlare_MultiMeshTest, can_be_created_without_blowing_up)
+{
+   AllegroFlare::MultiMesh multi_mesh;
+}
+
+
+TEST_F(AllegroFlare_MultiMeshTest, initialize__without_allegro_initialized__raises_an_error)
+{
+   AllegroFlare::MultiMesh multi_mesh;
+   std::string expected_error_message =
+      "MultiMesh::initialize: error: guard \"al_is_system_installed()\" not met";
+   ASSERT_THROW_WITH_MESSAGE(multi_mesh.initialize(), std::runtime_error, expected_error_message);
+}
+
+
+TEST_F(AllegroFlare_MultiMeshTestWithAllegroRenderingFixture, render__will_not_blow_up)
+{
+   AllegroFlare::MultiMesh multi_mesh;
+   multi_mesh.initialize();
+   multi_mesh.render();
+}
+
+
+TEST_F(AllegroFlare_MultiMeshTestWithAllegroRenderingFixture, CAPTURE__render__will_render_the_mesh)
+{
+   AllegroFlare::MultiMesh multi_mesh;
+   multi_mesh.initialize();
+   multi_mesh.render();
+   al_flip_display();
+}
+
+

--- a/tests/AllegroFlare/MultiMeshTest.cpp
+++ b/tests/AllegroFlare/MultiMeshTest.cpp
@@ -76,3 +76,20 @@ TEST_F(AllegroFlare_MultiMeshTestWithAllegroRenderingFixture, CAPTURE__remove__w
 }
 
 
+TEST_F(AllegroFlare_MultiMeshTestWithAllegroRenderingFixture,
+   remove__will_return_the_now_obsolete_index_number_that_has_replaced_the_removed_index_index_number)
+{
+   ALLEGRO_BITMAP *texture = get_bitmap_bin_ref()["uv.png"];
+   AllegroFlare::MultiMesh multi_mesh;
+   multi_mesh.set_texture(texture);
+   multi_mesh.initialize();
+
+   multi_mesh.append(300, 200, 100, 100);
+   multi_mesh.append(600, 300, 100, 100);
+   multi_mesh.append(1000, 500, 100, 100);
+
+   int moved_index = multi_mesh.remove(1);
+   EXPECT_EQ(2, moved_index);
+}
+
+

--- a/tests/AllegroFlare/MultiMeshUVAtlasTest.cpp
+++ b/tests/AllegroFlare/MultiMeshUVAtlasTest.cpp
@@ -1,0 +1,12 @@
+
+#include <gtest/gtest.h>
+
+#include <AllegroFlare/MultiMeshUVAtlas.hpp>
+
+
+TEST(AllegroFlare_MultiMeshUVAtlasTest, can_be_created_without_blowing_up)
+{
+   AllegroFlare::MultiMeshUVAtlas multi_mesh_uvatlas;
+}
+
+

--- a/tests/AllegroFlare/MultiMeshUVTest.cpp
+++ b/tests/AllegroFlare/MultiMeshUVTest.cpp
@@ -1,0 +1,12 @@
+
+#include <gtest/gtest.h>
+
+#include <AllegroFlare/MultiMeshUV.hpp>
+
+
+TEST(AllegroFlare_MultiMeshUVTest, can_be_created_without_blowing_up)
+{
+   AllegroFlare::MultiMeshUV multi_mesh_uv;
+}
+
+

--- a/tests/AllegroFlare/Network2/MessageTest.cpp
+++ b/tests/AllegroFlare/Network2/MessageTest.cpp
@@ -27,8 +27,8 @@ TEST(AllegroFlare_Network2_MessageTest,
    data___has_the_expected_size_which_is_the_sum_of_HEADER_LENGTH_and_MAX_BODY_LENGTH)
 {
    AllegroFlare::Network2::Message message;
-   int expected_data_size = AllegroFlare::Network2::Message::get_HEADER_LENGTH()
-                          + AllegroFlare::Network2::Message::get_MAX_BODY_LENGTH();
+   int expected_data_size = AllegroFlare::Network2::Message::HEADER_LENGTH
+                          + AllegroFlare::Network2::Message::MAX_BODY_LENGTH;
    EXPECT_EQ(expected_data_size, message.get_data().size());
 }
 
@@ -50,8 +50,8 @@ TEST(AllegroFlare_Network2_MessageTest, set_body_length__will_set_the_body_lengt
    message.set_body_length(1);
    EXPECT_EQ(1, message.get_body_length());
 
-   message.set_body_length(AllegroFlare::Network2::Message::get_MAX_BODY_LENGTH());
-   EXPECT_EQ(AllegroFlare::Network2::Message::get_MAX_BODY_LENGTH(), message.get_body_length());
+   message.set_body_length(AllegroFlare::Network2::Message::MAX_BODY_LENGTH);
+   EXPECT_EQ(AllegroFlare::Network2::Message::MAX_BODY_LENGTH, message.get_body_length());
 
    message.set_body_length(0);
    EXPECT_EQ(0, message.get_body_length());
@@ -63,7 +63,7 @@ TEST(AllegroFlare_Network2_MessageTest,
 {
    AllegroFlare::Network2::Message message;
 
-   std::size_t size_too_big = AllegroFlare::Network2::Message::get_MAX_BODY_LENGTH() + 1;
+   std::size_t size_too_big = AllegroFlare::Network2::Message::MAX_BODY_LENGTH + 1;
 
    std::string expected_error_message = "Message::set_body_length: error: "
                                         "guard \"(!(new_length > MAX_BODY_LENGTH))\" not met";
@@ -76,7 +76,7 @@ TEST(AllegroFlare_Network2_MessageTest,
 {
    AllegroFlare::Network2::Message message;
 
-   std::size_t size_too_big = AllegroFlare::Network2::Message::get_MAX_BODY_LENGTH() + 1;
+   std::size_t size_too_big = AllegroFlare::Network2::Message::MAX_BODY_LENGTH + 1;
    std::string content_too_big(size_too_big, 'x');
 
    std::string expected_error_message = "Message::set_body: error: "
@@ -88,7 +88,7 @@ TEST(AllegroFlare_Network2_MessageTest,
 TEST(AllegroFlare_Network2_MessageTest, set_body__will_set_the_body_length_to_match_the_size)
 {
    AllegroFlare::Network2::Message message;
-   std::vector<std::size_t> sizes_to_test = { 0, 10, 256, 112, 11, message.get_MAX_BODY_LENGTH() };
+   std::vector<std::size_t> sizes_to_test = { 0, 10, 256, 112, 11, AllegroFlare::Network2::Message::MAX_BODY_LENGTH };
 
    for (auto &size_to_test : sizes_to_test)
    {
@@ -114,7 +114,7 @@ TEST(AllegroFlare_Network2_MessageTest, set_body__will_set_the_expected_body_dat
 
    message.set_body(message_body_content);
 
-   std::string expected_data_chunk = message.get_data().substr(message.get_HEADER_LENGTH(), message.get_body_length());
+   std::string expected_data_chunk = message.get_data().substr(message.HEADER_LENGTH, message.get_body_length());
    EXPECT_EQ(message_body_content, expected_data_chunk);
 }
 
@@ -140,7 +140,7 @@ TEST(AllegroFlare_Network2_MessageTest,
       { "0048", 256 },
       { "001O", 112 },
       { "000b", 11 },
-      { "008g", message.get_MAX_BODY_LENGTH() },
+      { "008g", AllegroFlare::Network2::Message::MAX_BODY_LENGTH },
    };
 
    for (auto &size_datum_to_test : size_datas_to_test)
@@ -164,7 +164,7 @@ TEST(AllegroFlare_Network2_MessageTest,
 
    std::vector<std::tuple<std::string, std::size_t>> size_datas_to_test = {
       { "a738", 256 },
-      { "2d99", message.get_MAX_BODY_LENGTH() },
+      { "2d99", AllegroFlare::Network2::Message::MAX_BODY_LENGTH },
    };
 
    for (auto &size_datum_to_test : size_datas_to_test)
@@ -190,7 +190,7 @@ TEST(AllegroFlare_Network2_MessageTest,
       { "d14a", "" },
       { "61c6", "This is the content that will be hashed." },
       { "ddd1", "Content can be short" },
-      { "05d8", std::string(message.get_MAX_BODY_LENGTH(), 'x') }, // content can be long
+      { "05d8", std::string(AllegroFlare::Network2::Message::MAX_BODY_LENGTH, 'x') }, // content can be long
    };
 
    for (auto &expected_header_chunk_and_content_datum : expected_header_chunk_and_content_data)


### PR DESCRIPTION
# Multimesh

Multimesh is just a name I came up with for a simple concept - a vertex buffer that manages rectangular elements for maximum efficient drawing.

Multimesh essentially allows you to have a large number of rectangular "items" all stored in a vertex buffer, and upon drawing, will only render the rectangular items that are present, very efficiently with a single draw call on a vertex buffer object.

## Two points

- You can add rectangular items with `append()`. An integer value is returned representing the index, or position, of the item in the buffer.
- When you `remove()` an item by index, then that index will be re-issued to an existing item that was from the back of the list.  The number returned by `remove()` is the old, now no longer used index num of the item that was moved from the back.  You will need to update the old index of the moved object in your own code.

## Still Missing

`append` and `append_raw` need to return the added item's integer index. Will add that as a fast-follow after merging.

## Anicdotes

The class can probably be renamed. It also includes `MultiMeshUV` and `MultiMeshUVAtlas`. The atlas is basically an int-indexed list of `uv` coordinates for a texture.  That list is used by the `MultiMesh` to simplify building the items.

### Also

Implicitly, this branch also included an update to `Network2/Message` 🤷‍♂️.  It sets some constant properties to `constexpr`, now that that feature is available.