### PR TITLE
Replace "chat_message" with Network2/Message

### DIFF
--- a/include/AllegroFlare/Network2/Client.hpp
+++ b/include/AllegroFlare/Network2/Client.hpp
@@ -7,7 +7,8 @@
 #include <mutex>
 
 
-#include <AllegroFlare/Network2/inc/chat_message.hpp> // just for MESSAGE_BODY_LENGTH_MAX
+//#include <AllegroFlare/Network2/inc/chat_message.hpp> // just for MESSAGE_BODY_LENGTH_MAX
+#include <AllegroFlare/Network2/Message.hpp>
 
 
 namespace AllegroFlare
@@ -26,7 +27,7 @@ namespace AllegroFlare
          std::string port;
 
       public:
-         static constexpr std::size_t MESSAGE_BODY_LENGTH_MAX = chat_message::max_body_length;
+         static constexpr std::size_t MESSAGE_BODY_LENGTH_MAX = AllegroFlare::Network2::Message::MAX_BODY_LENGTH;
 
          Client(
             std::atomic<bool> *global_abort=nullptr,

--- a/include/AllegroFlare/Network2/Message.hpp
+++ b/include/AllegroFlare/Network2/Message.hpp
@@ -14,7 +14,7 @@ namespace AllegroFlare
       {
       public:
          static constexpr std::size_t HEADER_LENGTH = 16;
-         static constexpr std::size_t MAX_BODY_LENGTH = 512;
+         static constexpr std::size_t MAX_BODY_LENGTH = (512*4);
          static constexpr char* MAGIC_HEADER_CHUNK = "AFNM";
 
       private:

--- a/include/AllegroFlare/Network2/Server.hpp
+++ b/include/AllegroFlare/Network2/Server.hpp
@@ -6,7 +6,8 @@
 
 
 
-#include <AllegroFlare/Network2/inc/chat_message.hpp> // just for BODY_LENGTH_MAX
+//#include <AllegroFlare/Network2/inc/chat_message.hpp> // just for BODY_LENGTH_MAX
+#include <AllegroFlare/Network2/Message.hpp>
 
 
 namespace AllegroFlare
@@ -21,7 +22,7 @@ namespace AllegroFlare
          std::string port;
 
       public:
-         static constexpr std::size_t BODY_LENGTH_MAX = chat_message::max_body_length;
+         static constexpr std::size_t BODY_LENGTH_MAX = AllegroFlare::Network2::Message::MAX_BODY_LENGTH;
 
          Server(std::atomic<bool> *global_abort=nullptr);
          ~Server();

--- a/quintessence/AllegroFlare/Network2/Message.q.yml
+++ b/quintessence/AllegroFlare/Network2/Message.q.yml
@@ -12,7 +12,7 @@ properties:
     static: true
     const: true
     type: std::size_t
-    init_with: 512
+    init_with: (512*4)
     constexpr: true
 
   - name: MAGIC_HEADER_CHUNK

--- a/tests/AllegroFlare/Integrations/NetworkTest.cpp
+++ b/tests/AllegroFlare/Integrations/NetworkTest.cpp
@@ -105,6 +105,7 @@ TEST_F(AllegroFlare_Integrations_NetworkTest,
    std::thread publisher(
       publish_n_messages_every_m_seconds_for_j_seconds,
       &sending_messages_queue,
+
       &sending_messages_queue_mutex
    );
 

--- a/tests/AllegroFlare/Network2/MessageTest.cpp
+++ b/tests/AllegroFlare/Network2/MessageTest.cpp
@@ -140,7 +140,8 @@ TEST(AllegroFlare_Network2_MessageTest,
       { "0048", 256 },
       { "001O", 112 },
       { "000b", 11 },
-      { "008g", AllegroFlare::Network2::Message::MAX_BODY_LENGTH },
+      //{ "008g", AllegroFlare::Network2::Message::MAX_BODY_LENGTH }, // when MAX_BODY_LENGTH is 512
+      { "00x2", AllegroFlare::Network2::Message::MAX_BODY_LENGTH },
    };
 
    for (auto &size_datum_to_test : size_datas_to_test)
@@ -164,7 +165,8 @@ TEST(AllegroFlare_Network2_MessageTest,
 
    std::vector<std::tuple<std::string, std::size_t>> size_datas_to_test = {
       { "a738", 256 },
-      { "2d99", AllegroFlare::Network2::Message::MAX_BODY_LENGTH },
+      //{ "2d99", AllegroFlare::Network2::Message::MAX_BODY_LENGTH }, // when MAX_BODY_LENGTH is 512
+      { "5129", AllegroFlare::Network2::Message::MAX_BODY_LENGTH },
    };
 
    for (auto &size_datum_to_test : size_datas_to_test)
@@ -190,7 +192,8 @@ TEST(AllegroFlare_Network2_MessageTest,
       { "d14a", "" },
       { "61c6", "This is the content that will be hashed." },
       { "ddd1", "Content can be short" },
-      { "05d8", std::string(AllegroFlare::Network2::Message::MAX_BODY_LENGTH, 'x') }, // content can be long
+      //{ "05d8", std::string(AllegroFlare::Network2::Message::MAX_BODY_LENGTH, 'x') }, // when MAX_BODY_LENGTH is 512
+      { "f31a", std::string(AllegroFlare::Network2::Message::MAX_BODY_LENGTH, 'x') }, // when MAX_BODY_LENGTH is 512*4
    };
 
    for (auto &expected_header_chunk_and_content_datum : expected_header_chunk_and_content_data)


### PR DESCRIPTION
## About

`Network2/Message` was created to add a bit more security, flexibility, and debug-ability to `Network2`.  The previous legacy message, `chat_message`, still sits in an `inc/` folder and isn't setup for testing or expandability.

This PR replaces the usage of `chat_message` with `Network2/Message`, which, going forward, should make it easier and safer to modify/use (add more header data & message types, handle different message sizes, transfer across networks, etc).

## Note

In addition to all the tests passing, and the `Integrations/Network` tests passing, I tried out the `motion_edit` programs and they were able to transfer the messages as expected. I even had the experience of having to expand the `MAX_BODY_LENGTH` to accommodate the larger "AddActor2D" message.