### PR TITLE
Add Background and Foreground to Screens/Base

### DIFF
--- a/documentation/dependents.json
+++ b/documentation/dependents.json
@@ -1279,7 +1279,6 @@
     "AllegroFlare/Screens/LevelSelectScreen",
     "AllegroFlare/Screens/PauseScreen",
     "AllegroFlare/Screens/RollingCredits",
-    "AllegroFlare/Screens/Storyboard",
     "AllegroFlare/Screens/TitleScreen",
     "AllegroFlare/Screens/Version"
   ],

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -21283,10 +21283,6 @@ table td
   <td class="property">std::string</td>
 </tr>
 <tr>
-  <td class="property">background</td>
-  <td class="property">AllegroFlare::Elements::Backgrounds::Base*</td>
-</tr>
-<tr>
   <td class="property">initialized</td>
   <td class="property">bool</td>
 </tr>
@@ -21421,10 +21417,6 @@ table td
   <td class="property">AllegroFlare::SoftwareKeyboard::SoftwareKeyboard</td>
 </tr>
 <tr>
-  <td class="property">background</td>
-  <td class="property">AllegroFlare::Elements::Backgrounds::Base*</td>
-</tr>
-<tr>
   <td class="property">mode</td>
   <td class="property">int</td>
 </tr>
@@ -21547,10 +21539,6 @@ table td
 <tr>
   <td class="property">on_menu_choice_callback_func_user_data</td>
   <td class="property">void*</td>
-</tr>
-<tr>
-  <td class="property">background</td>
-  <td class="property">AllegroFlare::Elements::Backgrounds::Base*</td>
 </tr>
 <tr>
   <td class="property">cursor_position</td>
@@ -21696,10 +21684,6 @@ table td
 <tr>
   <td class="property">on_submit_callback_func_user_data</td>
   <td class="property">void*</td>
-</tr>
-<tr>
-  <td class="property">background</td>
-  <td class="property">AllegroFlare::Elements::Backgrounds::Base*</td>
 </tr>
 <tr>
   <td class="property">title_font_name</td>
@@ -21849,10 +21833,6 @@ table td
   <td class="property">AllegroFlare::Elements::InputDeviceConfigurationList</td>
 </tr>
 <tr>
-  <td class="property">background</td>
-  <td class="property">AllegroFlare::Elements::Backgrounds::Base*</td>
-</tr>
-<tr>
   <td class="property">initialized</td>
   <td class="property">bool</td>
 </tr>
@@ -21990,10 +21970,6 @@ table td
   <td class="property">void*</td>
 </tr>
 <tr>
-  <td class="property">background</td>
-  <td class="property">AllegroFlare::Elements::Backgrounds::Base*</td>
-</tr>
-<tr>
   <td class="property">initialized</td>
   <td class="property">bool</td>
 </tr>
@@ -22127,10 +22103,6 @@ table td
 <tr>
   <td class="property">on_menu_choice_callback_func_user_data</td>
   <td class="property">void*</td>
-</tr>
-<tr>
-  <td class="property">background</td>
-  <td class="property">AllegroFlare::Elements::Backgrounds::Base*</td>
 </tr>
 <tr>
   <td class="property">title_bitmap_name</td>
@@ -22380,10 +22352,6 @@ table td
   <td class="property">uint32_t</td>
 </tr>
 <tr>
-  <td class="property">background</td>
-  <td class="property">AllegroFlare::Elements::Backgrounds::Base*</td>
-</tr>
-<tr>
   <td class="property">DEFAULT_GAME_EVENT_NAME_TO_EMIT_AFTER_COMPLETING</td>
   <td class="property">char*</td>
 </tr>
@@ -22510,10 +22478,6 @@ table td
   <td class="property">uint32_t</td>
 </tr>
 <tr>
-  <td class="property">background</td>
-  <td class="property">AllegroFlare::Elements::Backgrounds::Base*</td>
-</tr>
-<tr>
   <td class="property">DEFAULT_GAME_EVENT_NAME_TO_EMIT_AFTER_COMPLETING</td>
   <td class="property">char*</td>
 </tr>
@@ -22596,9 +22560,6 @@ table td
 </tr>
 <tr>
   <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::Screens::Storyboard&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/Screens/Storyboard.hpp&quot;]}</td>
-</tr>
-<tr>
-  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;AllegroFlare::Elements::Backgrounds::Base&quot;, &quot;headers&quot;=&gt;[&quot;AllegroFlare/Elements/Backgrounds/Base.hpp&quot;]}</td>
 </tr>
     </table>
 </div>  </div>
@@ -22712,10 +22673,6 @@ table td
 <tr>
   <td class="property">on_finished_callback_func_user_data</td>
   <td class="property">void*</td>
-</tr>
-<tr>
-  <td class="property">background</td>
-  <td class="property">AllegroFlare::Elements::Backgrounds::Base*</td>
 </tr>
 <tr>
   <td class="property">title_position_x</td>
@@ -23146,10 +23103,6 @@ table td
 <tr>
   <td class="property">game_event_name_to_emit_on_exit</td>
   <td class="property">std::string</td>
-</tr>
-<tr>
-  <td class="property">background</td>
-  <td class="property">AllegroFlare::Elements::Backgrounds::Base*</td>
 </tr>
 <tr>
   <td class="property">initialized</td>
@@ -30663,7 +30616,6 @@ table td
     "AllegroFlare/Screens/LevelSelectScreen",
     "AllegroFlare/Screens/PauseScreen",
     "AllegroFlare/Screens/RollingCredits",
-    "AllegroFlare/Screens/Storyboard",
     "AllegroFlare/Screens/TitleScreen",
     "AllegroFlare/Screens/Version"
   ],

--- a/include/AllegroFlare/Screens/Achievements.hpp
+++ b/include/AllegroFlare/Screens/Achievements.hpp
@@ -3,7 +3,6 @@
 
 #include <AllegroFlare/Achievements.hpp>
 #include <AllegroFlare/Elements/AchievementsList.hpp>
-#include <AllegroFlare/Elements/Backgrounds/Base.hpp>
 #include <AllegroFlare/EventEmitter.hpp>
 #include <AllegroFlare/FontBin.hpp>
 #include <AllegroFlare/Player.hpp>
@@ -34,7 +33,6 @@ namespace AllegroFlare
          std::function<void(AllegroFlare::Screens::Achievements*, void*)> on_exit_callback_func;
          void* on_exit_callback_func_user_data;
          std::string game_event_name_to_emit_on_exit;
-         AllegroFlare::Elements::Backgrounds::Base* background;
          bool initialized;
          void update();
          void call_on_exit_callback();
@@ -48,18 +46,16 @@ namespace AllegroFlare
 
 
       public:
-         Achievements(AllegroFlare::FontBin* font_bin=nullptr, AllegroFlare::EventEmitter* event_emitter=nullptr, AllegroFlare::Achievements* achievements=nullptr, float scrollbar_dest_position=0.0f, std::string game_event_name_to_emit_on_exit=DEFAULT_EVENT_NAME_ON_EXIT, AllegroFlare::Elements::Backgrounds::Base* background=nullptr);
+         Achievements(AllegroFlare::FontBin* font_bin=nullptr, AllegroFlare::EventEmitter* event_emitter=nullptr, AllegroFlare::Achievements* achievements=nullptr, float scrollbar_dest_position=0.0f, std::string game_event_name_to_emit_on_exit=DEFAULT_EVENT_NAME_ON_EXIT);
          virtual ~Achievements();
 
          void set_achievements(AllegroFlare::Achievements* achievements);
          void set_on_exit_callback_func(std::function<void(AllegroFlare::Screens::Achievements*, void*)> on_exit_callback_func);
          void set_on_exit_callback_func_user_data(void* on_exit_callback_func_user_data);
          void set_game_event_name_to_emit_on_exit(std::string game_event_name_to_emit_on_exit);
-         void set_background(AllegroFlare::Elements::Backgrounds::Base* background);
          std::function<void(AllegroFlare::Screens::Achievements*, void*)> get_on_exit_callback_func() const;
          void* get_on_exit_callback_func_user_data() const;
          std::string get_game_event_name_to_emit_on_exit() const;
-         AllegroFlare::Elements::Backgrounds::Base* get_background() const;
          AllegroFlare::Elements::AchievementsList &get_achievements_list_ref();
          void set_font_bin(AllegroFlare::FontBin* font_bin=nullptr);
          void set_event_emitter(AllegroFlare::EventEmitter* event_emitter=nullptr);

--- a/include/AllegroFlare/Screens/Base.hpp
+++ b/include/AllegroFlare/Screens/Base.hpp
@@ -19,8 +19,8 @@ namespace AllegroFlare
       {
       private:
          std::string type;
-         //AllegroFlare::Elements::Backgrounds::Base *background;
-         //AllegroFlare::Elements::Backgrounds::Base *foreground;
+         AllegroFlare::Elements::Backgrounds::Base *background;
+         AllegroFlare::Elements::Backgrounds::Base *foreground;
 
       public:
          Base(std::string type="Base");
@@ -29,6 +29,11 @@ namespace AllegroFlare
          //void set_type(std::string type);
          std::string get_type();
          bool is_type(std::string possible_type);
+
+         void set_background(AllegroFlare::Elements::Backgrounds::Base *background=nullptr);
+         void set_foreground(AllegroFlare::Elements::Backgrounds::Base *foreground=nullptr);
+         AllegroFlare::Elements::Backgrounds::Base *get_background();
+         AllegroFlare::Elements::Backgrounds::Base *get_foreground();
 
          virtual void managed_primary_timer_func() final; // renders the background and foreground
 

--- a/include/AllegroFlare/Screens/Base.hpp
+++ b/include/AllegroFlare/Screens/Base.hpp
@@ -36,9 +36,11 @@ namespace AllegroFlare
          AllegroFlare::Elements::Backgrounds::Base *get_foreground();
 
          virtual void managed_primary_timer_func() final; // renders the background and foreground
+         virtual void managed_on_activate() final;
+         virtual void managed_on_deactivate() final;
 
-         virtual void on_activate(); // activated through the manager
-         virtual void on_deactivate(); // deactivated thorugh the screen manager
+         virtual void on_activate(); // When controlled/managed through a ScreenManagers/*
+         virtual void on_deactivate(); // When controlled/managed through a ScreenManagers/*
          virtual void on_event(ALLEGRO_EVENT *ev);
          virtual void primary_timer_func();
          virtual void timer_func();

--- a/include/AllegroFlare/Screens/CharacterNameInput.hpp
+++ b/include/AllegroFlare/Screens/CharacterNameInput.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 
-#include <AllegroFlare/Elements/Backgrounds/Base.hpp>
 #include <AllegroFlare/EventEmitter.hpp>
 #include <AllegroFlare/FontBin.hpp>
 #include <AllegroFlare/Player.hpp>
@@ -26,7 +25,6 @@ namespace AllegroFlare
          AllegroFlare::EventEmitter* event_emitter;
          AllegroFlare::FontBin* font_bin;
          AllegroFlare::SoftwareKeyboard::SoftwareKeyboard software_keyboard;
-         AllegroFlare::Elements::Backgrounds::Base* background;
          int mode;
          bool initialized;
 
@@ -34,13 +32,11 @@ namespace AllegroFlare
 
 
       public:
-         CharacterNameInput(AllegroFlare::EventEmitter* event_emitter=nullptr, AllegroFlare::FontBin* font_bin=nullptr, AllegroFlare::SoftwareKeyboard::SoftwareKeyboard software_keyboard={}, AllegroFlare::Elements::Backgrounds::Base* background=nullptr);
+         CharacterNameInput(AllegroFlare::EventEmitter* event_emitter=nullptr, AllegroFlare::FontBin* font_bin=nullptr, AllegroFlare::SoftwareKeyboard::SoftwareKeyboard software_keyboard={});
          virtual ~CharacterNameInput();
 
          void set_event_emitter(AllegroFlare::EventEmitter* event_emitter);
          void set_font_bin(AllegroFlare::FontBin* font_bin);
-         void set_background(AllegroFlare::Elements::Backgrounds::Base* background);
-         AllegroFlare::Elements::Backgrounds::Base* get_background() const;
          void initialize();
          virtual void on_activate() override;
          virtual void on_deactivate() override;

--- a/include/AllegroFlare/Screens/GameOverScreen.hpp
+++ b/include/AllegroFlare/Screens/GameOverScreen.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 
-#include <AllegroFlare/Elements/Backgrounds/Base.hpp>
 #include <AllegroFlare/EventEmitter.hpp>
 #include <AllegroFlare/FontBin.hpp>
 #include <AllegroFlare/Player.hpp>
@@ -28,7 +27,6 @@ namespace AllegroFlare
          std::vector<std::pair<std::string, std::string>> menu_options;
          std::function<void(AllegroFlare::Screens::GameOverScreen*, void*)> on_menu_choice_callback_func;
          void* on_menu_choice_callback_func_user_data;
-         AllegroFlare::Elements::Backgrounds::Base* background;
          int cursor_position;
          std::string title_font_name;
          int title_font_size;
@@ -57,14 +55,12 @@ namespace AllegroFlare
          void set_title_text(std::string title_text);
          void set_on_menu_choice_callback_func(std::function<void(AllegroFlare::Screens::GameOverScreen*, void*)> on_menu_choice_callback_func);
          void set_on_menu_choice_callback_func_user_data(void* on_menu_choice_callback_func_user_data);
-         void set_background(AllegroFlare::Elements::Backgrounds::Base* background);
          void set_title_font_name(std::string title_font_name);
          void set_title_font_size(int title_font_size);
          void set_menu_font_name(std::string menu_font_name);
          void set_menu_font_size(int menu_font_size);
          std::function<void(AllegroFlare::Screens::GameOverScreen*, void*)> get_on_menu_choice_callback_func() const;
          void* get_on_menu_choice_callback_func_user_data() const;
-         AllegroFlare::Elements::Backgrounds::Base* get_background() const;
          std::string get_title_font_name() const;
          int get_title_font_size() const;
          std::string get_menu_font_name() const;

--- a/include/AllegroFlare/Screens/GameWonScreen.hpp
+++ b/include/AllegroFlare/Screens/GameWonScreen.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 
-#include <AllegroFlare/Elements/Backgrounds/Base.hpp>
 #include <AllegroFlare/EventEmitter.hpp>
 #include <AllegroFlare/FontBin.hpp>
 #include <AllegroFlare/Player.hpp>
@@ -25,7 +24,6 @@ namespace AllegroFlare
          std::string title_text;
          std::function<void(AllegroFlare::Screens::GameWonScreen*, void*)> on_submit_callback_func;
          void* on_submit_callback_func_user_data;
-         AllegroFlare::Elements::Backgrounds::Base* background;
          std::string title_font_name;
          int title_font_size;
          std::string instruction_text;
@@ -41,7 +39,7 @@ namespace AllegroFlare
 
 
       public:
-         GameWonScreen(AllegroFlare::EventEmitter* event_emitter=nullptr, AllegroFlare::FontBin* font_bin=nullptr, std::string title_text=DEFAULT_TITLE_TEXT, AllegroFlare::Elements::Backgrounds::Base* background=nullptr, std::string title_font_name="Inter-Regular.ttf", int title_font_size=-64, std::string instruction_text=DEFAULT_INSTRUCTION_TEXT, std::string instruction_font_name="Inter-Regular.ttf", int instruction_font_size=-32, std::string game_event_name_to_emit_on_submission="game_won_finished");
+         GameWonScreen(AllegroFlare::EventEmitter* event_emitter=nullptr, AllegroFlare::FontBin* font_bin=nullptr, std::string title_text=DEFAULT_TITLE_TEXT, std::string title_font_name="Inter-Regular.ttf", int title_font_size=-64, std::string instruction_text=DEFAULT_INSTRUCTION_TEXT, std::string instruction_font_name="Inter-Regular.ttf", int instruction_font_size=-32, std::string game_event_name_to_emit_on_submission="game_won_finished");
          virtual ~GameWonScreen();
 
          void set_event_emitter(AllegroFlare::EventEmitter* event_emitter);
@@ -49,7 +47,6 @@ namespace AllegroFlare
          void set_title_text(std::string title_text);
          void set_on_submit_callback_func(std::function<void(AllegroFlare::Screens::GameWonScreen*, void*)> on_submit_callback_func);
          void set_on_submit_callback_func_user_data(void* on_submit_callback_func_user_data);
-         void set_background(AllegroFlare::Elements::Backgrounds::Base* background);
          void set_title_font_name(std::string title_font_name);
          void set_title_font_size(int title_font_size);
          void set_instruction_text(std::string instruction_text);
@@ -58,7 +55,6 @@ namespace AllegroFlare
          void set_game_event_name_to_emit_on_submission(std::string game_event_name_to_emit_on_submission);
          std::function<void(AllegroFlare::Screens::GameWonScreen*, void*)> get_on_submit_callback_func() const;
          void* get_on_submit_callback_func_user_data() const;
-         AllegroFlare::Elements::Backgrounds::Base* get_background() const;
          std::string get_title_font_name() const;
          int get_title_font_size() const;
          std::string get_instruction_font_name() const;

--- a/include/AllegroFlare/Screens/InputDeviceConfiguration.hpp
+++ b/include/AllegroFlare/Screens/InputDeviceConfiguration.hpp
@@ -2,7 +2,6 @@
 
 
 #include <AllegroFlare/BitmapBin.hpp>
-#include <AllegroFlare/Elements/Backgrounds/Base.hpp>
 #include <AllegroFlare/Elements/InputDeviceConfigurationList.hpp>
 #include <AllegroFlare/Elements/InputDevicesList.hpp>
 #include <AllegroFlare/EventEmitter.hpp>
@@ -37,7 +36,6 @@ namespace AllegroFlare
          AllegroFlare::InputDevicesList* input_devices_list;
          AllegroFlare::Elements::InputDevicesList input_devices_list_element;
          AllegroFlare::Elements::InputDeviceConfigurationList input_device_configuration_element;
-         AllegroFlare::Elements::Backgrounds::Base* background;
          bool initialized;
          void call_on_exit_callback();
 
@@ -52,12 +50,10 @@ namespace AllegroFlare
          void set_surface_height(std::size_t surface_height);
          void set_on_exit_callback_func(std::function<void(AllegroFlare::Screens::InputDeviceConfiguration*, void*)> on_exit_callback_func);
          void set_on_exit_callback_func_user_data(void* on_exit_callback_func_user_data);
-         void set_background(AllegroFlare::Elements::Backgrounds::Base* background);
          std::size_t get_surface_width() const;
          std::size_t get_surface_height() const;
          std::function<void(AllegroFlare::Screens::InputDeviceConfiguration*, void*)> get_on_exit_callback_func() const;
          void* get_on_exit_callback_func_user_data() const;
-         AllegroFlare::Elements::Backgrounds::Base* get_background() const;
          AllegroFlare::Elements::InputDevicesList &get_input_devices_list_element_ref();
          AllegroFlare::Elements::InputDeviceConfigurationList &get_input_device_configuration_element_ref();
          void set_event_emitter(AllegroFlare::EventEmitter* event_emitter=nullptr);

--- a/include/AllegroFlare/Screens/LevelSelectScreen.hpp
+++ b/include/AllegroFlare/Screens/LevelSelectScreen.hpp
@@ -2,7 +2,6 @@
 
 
 #include <AllegroFlare/BitmapBin.hpp>
-#include <AllegroFlare/Elements/Backgrounds/Base.hpp>
 #include <AllegroFlare/Elements/LevelSelect.hpp>
 #include <AllegroFlare/EventEmitter.hpp>
 #include <AllegroFlare/FontBin.hpp>
@@ -33,7 +32,6 @@ namespace AllegroFlare
          AllegroFlare::Elements::LevelSelect level_select_element;
          std::function<void(AllegroFlare::Screens::LevelSelectScreen*, void*)> on_menu_choice_callback_func;
          void* on_menu_choice_callback_func_user_data;
-         AllegroFlare::Elements::Backgrounds::Base* background;
          bool initialized;
 
       protected:
@@ -45,10 +43,8 @@ namespace AllegroFlare
 
          void set_on_menu_choice_callback_func(std::function<void(AllegroFlare::Screens::LevelSelectScreen*, void*)> on_menu_choice_callback_func);
          void set_on_menu_choice_callback_func_user_data(void* on_menu_choice_callback_func_user_data);
-         void set_background(AllegroFlare::Elements::Backgrounds::Base* background);
          std::function<void(AllegroFlare::Screens::LevelSelectScreen*, void*)> get_on_menu_choice_callback_func() const;
          void* get_on_menu_choice_callback_func_user_data() const;
-         AllegroFlare::Elements::Backgrounds::Base* get_background() const;
          AllegroFlare::Elements::LevelSelect &get_level_select_element_ref();
          void set_event_emitter(AllegroFlare::EventEmitter* event_emitter=nullptr);
          void set_bitmap_bin(AllegroFlare::BitmapBin* bitmap_bin=nullptr);

--- a/include/AllegroFlare/Screens/PauseScreen.hpp
+++ b/include/AllegroFlare/Screens/PauseScreen.hpp
@@ -2,7 +2,6 @@
 
 
 #include <AllegroFlare/BitmapBin.hpp>
-#include <AllegroFlare/Elements/Backgrounds/Base.hpp>
 #include <AllegroFlare/EventEmitter.hpp>
 #include <AllegroFlare/FontBin.hpp>
 #include <AllegroFlare/Player.hpp>
@@ -31,7 +30,6 @@ namespace AllegroFlare
          std::string footer_text;
          std::function<void(AllegroFlare::Screens::PauseScreen*, void*)> on_menu_choice_callback_func;
          void* on_menu_choice_callback_func_user_data;
-         AllegroFlare::Elements::Backgrounds::Base* background;
          std::string title_bitmap_name;
          std::string font_name;
          ALLEGRO_COLOR title_text_color;
@@ -71,7 +69,6 @@ namespace AllegroFlare
          void set_footer_text(std::string footer_text);
          void set_on_menu_choice_callback_func(std::function<void(AllegroFlare::Screens::PauseScreen*, void*)> on_menu_choice_callback_func);
          void set_on_menu_choice_callback_func_user_data(void* on_menu_choice_callback_func_user_data);
-         void set_background(AllegroFlare::Elements::Backgrounds::Base* background);
          void set_title_bitmap_name(std::string title_bitmap_name);
          void set_font_name(std::string font_name);
          void set_title_text_color(ALLEGRO_COLOR title_text_color);
@@ -87,7 +84,6 @@ namespace AllegroFlare
          std::string get_footer_text() const;
          std::function<void(AllegroFlare::Screens::PauseScreen*, void*)> get_on_menu_choice_callback_func() const;
          void* get_on_menu_choice_callback_func_user_data() const;
-         AllegroFlare::Elements::Backgrounds::Base* get_background() const;
          std::string get_title_bitmap_name() const;
          std::string get_font_name() const;
          ALLEGRO_COLOR get_title_text_color() const;

--- a/include/AllegroFlare/Screens/RollingCredits.hpp
+++ b/include/AllegroFlare/Screens/RollingCredits.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 
-#include <AllegroFlare/Elements/Backgrounds/Base.hpp>
 #include <AllegroFlare/Elements/RollingCredits/RollingCredits.hpp>
 #include <AllegroFlare/Elements/RollingCredits/Sections/Base.hpp>
 #include <AllegroFlare/EventEmitter.hpp>
@@ -37,7 +36,6 @@ namespace AllegroFlare
          float cached_calculated_height;
          std::string game_event_name_to_emit_after_completing;
          uint32_t route_event_to_emit_after_completing;
-         AllegroFlare::Elements::Backgrounds::Base* background;
          bool scroll_is_past_end;
          bool initialized;
          void emit_completion_event();
@@ -58,7 +56,6 @@ namespace AllegroFlare
          void set_on_finished_callback_func_user_data(void* on_finished_callback_func_user_data);
          void set_game_event_name_to_emit_after_completing(std::string game_event_name_to_emit_after_completing);
          void set_route_event_to_emit_after_completing(uint32_t route_event_to_emit_after_completing);
-         void set_background(AllegroFlare::Elements::Backgrounds::Base* background);
          AllegroFlare::Elements::RollingCredits::RollingCredits get_rolling_credits_component() const;
          float get_surface_width() const;
          float get_surface_height() const;
@@ -69,7 +66,6 @@ namespace AllegroFlare
          float get_cached_calculated_height() const;
          std::string get_game_event_name_to_emit_after_completing() const;
          uint32_t get_route_event_to_emit_after_completing() const;
-         AllegroFlare::Elements::Backgrounds::Base* get_background() const;
          bool get_scroll_is_past_end() const;
          AllegroFlare::Elements::RollingCredits::RollingCredits &get_rolling_credits_component_ref();
          float &get_y_offset_ref();

--- a/include/AllegroFlare/Screens/Storyboard.hpp
+++ b/include/AllegroFlare/Screens/Storyboard.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 
-#include <AllegroFlare/Elements/Backgrounds/Base.hpp>
 #include <AllegroFlare/Elements/Storyboard.hpp>
 #include <AllegroFlare/EventEmitter.hpp>
 #include <AllegroFlare/FontBin.hpp>
@@ -33,7 +32,6 @@ namespace AllegroFlare
          bool auto_advance;
          std::string game_event_name_to_emit_after_completing;
          uint32_t route_event_to_emit_after_completing;
-         AllegroFlare::Elements::Backgrounds::Base* background;
          bool initialized;
          void emit_completion_event();
          void advance();
@@ -52,13 +50,11 @@ namespace AllegroFlare
          void set_auto_advance(bool auto_advance);
          void set_game_event_name_to_emit_after_completing(std::string game_event_name_to_emit_after_completing);
          void set_route_event_to_emit_after_completing(uint32_t route_event_to_emit_after_completing);
-         void set_background(AllegroFlare::Elements::Backgrounds::Base* background);
          std::function<void(AllegroFlare::Screens::Storyboard*, void*)> get_on_finished_callback_func() const;
          void* get_on_finished_callback_func_user_data() const;
          bool get_auto_advance() const;
          std::string get_game_event_name_to_emit_after_completing() const;
          uint32_t get_route_event_to_emit_after_completing() const;
-         AllegroFlare::Elements::Backgrounds::Base* get_background() const;
          AllegroFlare::Elements::Storyboard &get_storyboard_element_ref();
          void initialize();
          virtual void on_activate() override;

--- a/include/AllegroFlare/Screens/TitleScreen.hpp
+++ b/include/AllegroFlare/Screens/TitleScreen.hpp
@@ -2,7 +2,6 @@
 
 
 #include <AllegroFlare/BitmapBin.hpp>
-#include <AllegroFlare/Elements/Backgrounds/Base.hpp>
 #include <AllegroFlare/EventEmitter.hpp>
 #include <AllegroFlare/FontBin.hpp>
 #include <AllegroFlare/Player.hpp>
@@ -59,7 +58,6 @@ namespace AllegroFlare
          void* on_menu_choice_callback_func_user_data;
          std::function<void(AllegroFlare::Screens::TitleScreen*, void*)> on_finished_callback_func;
          void* on_finished_callback_func_user_data;
-         AllegroFlare::Elements::Backgrounds::Base* background;
          float title_position_x;
          float title_position_y;
          float menu_position_x;
@@ -122,7 +120,6 @@ namespace AllegroFlare
          void set_on_menu_choice_callback_func_user_data(void* on_menu_choice_callback_func_user_data);
          void set_on_finished_callback_func(std::function<void(AllegroFlare::Screens::TitleScreen*, void*)> on_finished_callback_func);
          void set_on_finished_callback_func_user_data(void* on_finished_callback_func_user_data);
-         void set_background(AllegroFlare::Elements::Backgrounds::Base* background);
          void set_title_position_x(float title_position_x);
          void set_title_position_y(float title_position_y);
          void set_menu_position_x(float menu_position_x);
@@ -156,7 +153,6 @@ namespace AllegroFlare
          void* get_on_menu_choice_callback_func_user_data() const;
          std::function<void(AllegroFlare::Screens::TitleScreen*, void*)> get_on_finished_callback_func() const;
          void* get_on_finished_callback_func_user_data() const;
-         AllegroFlare::Elements::Backgrounds::Base* get_background() const;
          float get_title_position_x() const;
          float get_title_position_y() const;
          float get_menu_position_x() const;

--- a/include/AllegroFlare/Screens/Version.hpp
+++ b/include/AllegroFlare/Screens/Version.hpp
@@ -2,7 +2,6 @@
 
 
 #include <AllegroFlare/BitmapBin.hpp>
-#include <AllegroFlare/Elements/Backgrounds/Base.hpp>
 #include <AllegroFlare/Elements/RollingCredits/RollingCredits.hpp>
 #include <AllegroFlare/EventEmitter.hpp>
 #include <AllegroFlare/FontBin.hpp>
@@ -38,7 +37,6 @@ namespace AllegroFlare
          std::function<void(AllegroFlare::Screens::Version*, void*)> on_exit_callback_func;
          void* on_exit_callback_func_user_data;
          std::string game_event_name_to_emit_on_exit;
-         AllegroFlare::Elements::Backgrounds::Base* background;
          bool initialized;
 
       protected:
@@ -53,14 +51,12 @@ namespace AllegroFlare
          void set_on_exit_callback_func(std::function<void(AllegroFlare::Screens::Version*, void*)> on_exit_callback_func);
          void set_on_exit_callback_func_user_data(void* on_exit_callback_func_user_data);
          void set_game_event_name_to_emit_on_exit(std::string game_event_name_to_emit_on_exit);
-         void set_background(AllegroFlare::Elements::Backgrounds::Base* background);
          float get_surface_width() const;
          float get_surface_height() const;
          float get_cached_calculated_height() const;
          std::function<void(AllegroFlare::Screens::Version*, void*)> get_on_exit_callback_func() const;
          void* get_on_exit_callback_func_user_data() const;
          std::string get_game_event_name_to_emit_on_exit() const;
-         AllegroFlare::Elements::Backgrounds::Base* get_background() const;
          void set_event_emitter(AllegroFlare::EventEmitter* event_emitter=nullptr);
          void set_bitmap_bin(AllegroFlare::BitmapBin* bitmap_bin=nullptr);
          void set_font_bin(AllegroFlare::FontBin* font_bin=nullptr);

--- a/quintessence/AllegroFlare/Screens/Achievements.q.yml
+++ b/quintessence/AllegroFlare/Screens/Achievements.q.yml
@@ -56,13 +56,6 @@ properties:
     getter: true
     setter: true
 
-  - name: background
-    type: AllegroFlare::Elements::Backgrounds::Base*
-    init_with: nullptr
-    constructor_arg: true
-    setter: true
-    getter: true
-
   - name: initialized
     type: bool
     init_with: false
@@ -127,7 +120,6 @@ functions:
     override: true
     guards: [ initialized ]
     body: |
-      if (background) background->activate();
       // refresh the achievements from the actual list of achievements
       refresh_achievements_list();
 
@@ -146,7 +138,6 @@ functions:
     override: true
     guards: [ initialized ]
     body: |
-      if (background) background->deactivate();
       // emit events to show and set the input hints
       // TODO: add ALLEGRO_FLARE_EVENT_CLEAR_INPUT_HINTS_BAR
       event_emitter->emit_set_input_hints_bar_event({});
@@ -184,7 +175,6 @@ functions:
     private: true
     guards: [ initialized ]
     body: |
-      if (background) background->update();
       float scrollbar_position = achievements_list.get_scrollbar_position();
       if (scrollbar_position != scrollbar_dest_position)
       {
@@ -280,7 +270,6 @@ functions:
     xprivate: true
     guards: [ initialized ]
     body: |
-      if (background) background->render();
       achievements_list.render();
       return;
     body_dependency_symbols:

--- a/quintessence/AllegroFlare/Screens/CharacterNameInput.q.yml
+++ b/quintessence/AllegroFlare/Screens/CharacterNameInput.q.yml
@@ -26,13 +26,6 @@ properties:
     constructor_arg: true
     init_with: '{}'
 
-  - name: background
-    type: AllegroFlare::Elements::Backgrounds::Base*
-    init_with: nullptr
-    constructor_arg: true
-    setter: true
-    getter: true
-
   - name: mode
     type: int
     init_with: MODE_USING_VIRTUAL_CONTROLS
@@ -77,7 +70,6 @@ functions:
     override: true
     guards: [ initialized ]
     body: |
-      if (background) background->activate();
       software_keyboard.reset();
       return;
 
@@ -87,7 +79,6 @@ functions:
     override: true
     guards: [ initialized ]
     body: |
-      if (background) background->deactivate();
       return;
 
 
@@ -96,8 +87,6 @@ functions:
     override: true
     guards: [ initialized ]
     body: |
-      if (background) background->update();
-      if (background) background->render();
       render();
       return;
 

--- a/quintessence/AllegroFlare/Screens/GameOverScreen.q.yml
+++ b/quintessence/AllegroFlare/Screens/GameOverScreen.q.yml
@@ -44,12 +44,6 @@ properties:
     getter: true
     setter: true
 
-  - name: background
-    type: AllegroFlare::Elements::Backgrounds::Base*
-    init_with: nullptr
-    setter: true
-    getter: true
-
   - name: cursor_position
     type: int
     init_with: 0
@@ -141,7 +135,6 @@ functions:
     virtual: true
     override: true
     body: |
-      if (background) background->activate();
       return;
 
 
@@ -149,7 +142,6 @@ functions:
     virtual: true
     override: true
     body: |
-      if (background) background->deactivate();
       return;
 
 
@@ -184,8 +176,6 @@ functions:
     virtual: true
     override: true
     body: |
-      if (background) background->update();
-      if (background) background->render();
       render();
       return;
 

--- a/quintessence/AllegroFlare/Screens/GameWonScreen.q.yml
+++ b/quintessence/AllegroFlare/Screens/GameWonScreen.q.yml
@@ -39,13 +39,6 @@ properties:
     getter: true
     setter: true
 
-  - name: background
-    type: AllegroFlare::Elements::Backgrounds::Base*
-    init_with: nullptr
-    constructor_arg: true
-    setter: true
-    getter: true
-
   - name: title_font_name
     type: std::string
     init_with: '"Inter-Regular.ttf"'
@@ -116,7 +109,6 @@ functions:
     virtual: true
     override: true
     body: |
-      if (background) background->activate();
       return;
 
 
@@ -124,7 +116,6 @@ functions:
     virtual: true
     override: true
     body: |
-      if (background) background->deactivate();
       return;
 
 
@@ -132,8 +123,6 @@ functions:
     virtual: true
     override: true
     body: |
-      if (background) background->update();
-      if (background) background->render();
       render();
       return;
 

--- a/quintessence/AllegroFlare/Screens/InputDeviceConfiguration.q.yml
+++ b/quintessence/AllegroFlare/Screens/InputDeviceConfiguration.q.yml
@@ -69,12 +69,6 @@ properties:
     init_with: ''
     getter_ref: true
 
-  - name: background
-    type: AllegroFlare::Elements::Backgrounds::Base*
-    init_with: nullptr
-    setter: true
-    getter: true
-
   - name: initialized
     type: bool
     init_with: false
@@ -169,7 +163,6 @@ functions:
     override: true
     guards: [ initialized ]
     body: |
-      if (background) background->activate();
       //emit_event_to_update_input_hints_bar();
       //emit_show_and_size_input_hints_bar_event();
       return;
@@ -180,7 +173,6 @@ functions:
     override: true
     guards: [ initialized ]
     body: |
-      if (background) background->deactivate();
       //emit_hide_and_restore_size_input_hints_bar_event();
       return;
 
@@ -202,9 +194,7 @@ functions:
     override: true
     guards: [ initialized ]
     body: |
-      if (background) background->update();
       update();
-      if (background) background->render();
       render();
       return;
 

--- a/quintessence/AllegroFlare/Screens/LevelSelectScreen.q.yml
+++ b/quintessence/AllegroFlare/Screens/LevelSelectScreen.q.yml
@@ -41,12 +41,6 @@ properties:
     getter: true
     setter: true
 
-  - name: background
-    type: AllegroFlare::Elements::Backgrounds::Base*
-    init_with: nullptr
-    setter: true
-    getter: true
-
   - name: initialized
     type: bool
     init_with: false
@@ -133,7 +127,6 @@ functions:
     override: true
     guards: [ initialized ]
     body: |
-      if (background) background->activate();
       //emit_event_to_update_input_hints_bar();
       //emit_show_and_size_input_hints_bar_event();
       return;
@@ -144,7 +137,6 @@ functions:
     override: true
     guards: [ initialized ]
     body: |
-      if (background) background->deactivate();
       //emit_hide_and_restore_size_input_hints_bar_event();
       return;
 
@@ -181,9 +173,7 @@ functions:
     override: true
     guards: [ initialized ]
     body: |
-      if (background) background->update();
       update();
-      if (background) background->render();
       render();
       return;
 

--- a/quintessence/AllegroFlare/Screens/PauseScreen.q.yml
+++ b/quintessence/AllegroFlare/Screens/PauseScreen.q.yml
@@ -53,12 +53,6 @@ properties:
     getter: true
     setter: true
 
-  - name: background
-    type: AllegroFlare::Elements::Backgrounds::Base*
-    init_with: nullptr
-    getter: true
-    setter: true
-
   - name: title_bitmap_name
     type: std::string
     init_with: '""'
@@ -153,7 +147,6 @@ functions:
     virtual: true
     override: true
     body: |
-      if (background) background->activate();
       cursor_position = 0;
       return;
 
@@ -162,7 +155,6 @@ functions:
     virtual: true
     override: true
     body: |
-      if (background) background->deactivate();
       return;
 
 
@@ -235,8 +227,6 @@ functions:
     virtual: true
     override: true
     body: |
-      if (background) background->update();
-      if (background) background->render();
       render();
       return;
 

--- a/quintessence/AllegroFlare/Screens/RollingCredits.q.yml
+++ b/quintessence/AllegroFlare/Screens/RollingCredits.q.yml
@@ -86,12 +86,6 @@ properties:
     getter: true
     setter: true
 
-  - name: background
-    type: AllegroFlare::Elements::Backgrounds::Base*
-    init_with: nullptr
-    setter: true
-    getter: true
-
   - name: DEFAULT_GAME_EVENT_NAME_TO_EMIT_AFTER_COMPLETING
     type: char*
     init_with: '(char*)"rolling_credits_finished"'
@@ -122,7 +116,6 @@ functions:
     override: true
     guards: [ initialized ] 
     body: |
-      if (background) background->activate();
       y_offset = -surface_height;
       scroll_is_past_end = false;
       return;
@@ -133,7 +126,6 @@ functions:
     override: true
     guards: [ initialized ] 
     body: |
-      if (background) background->deactivate();
       return;
 
 
@@ -261,9 +253,7 @@ functions:
     override: true
     guards: [ al_is_system_installed(), al_is_font_addon_initialized() ]
     body: |
-      if (background) background->update();
       update();
-      if (background) background->render();
       render();
       return;
 

--- a/quintessence/AllegroFlare/Screens/Storyboard.q.yml
+++ b/quintessence/AllegroFlare/Screens/Storyboard.q.yml
@@ -59,12 +59,6 @@ properties:
     getter: true
     setter: true
 
-  - name: background
-    type: AllegroFlare::Elements::Backgrounds::Base*
-    init_with: nullptr
-    setter: true
-    getter: true
-
   - name: DEFAULT_GAME_EVENT_NAME_TO_EMIT_AFTER_COMPLETING
     type: char*
     init_with: '(char*)"storyboard_finished"'
@@ -98,7 +92,6 @@ functions:
     override: true
     guards: [ initialized ] 
     body: |
-      if (background) background->activate();
       storyboard_element.reset();
       if (storyboard_element.infer_has_no_pages())
       {
@@ -117,7 +110,6 @@ functions:
     override: true
     guards: [ initialized ] 
     body: |
-      if (background) background->deactivate();
       return;
 
 
@@ -126,12 +118,10 @@ functions:
     override: true
     guards: [ initialized ] 
     body: |
-      if (background) background->update();
 
       storyboard_element.update();
       if (storyboard_element.get_can_advance_to_next_page() && auto_advance) advance();
 
-      if (background) background->render();
       storyboard_element.render();
       return;
 
@@ -250,7 +240,5 @@ dependencies:
     headers: [ AllegroFlare/Logger.hpp ]
   - symbol: AllegroFlare::Screens::Storyboard
     headers: [ AllegroFlare/Screens/Storyboard.hpp ]
-  - symbol: AllegroFlare::Elements::Backgrounds::Base
-    headers: [ AllegroFlare/Elements/Backgrounds/Base.hpp ]
 
 

--- a/quintessence/AllegroFlare/Screens/TitleScreen.q.yml
+++ b/quintessence/AllegroFlare/Screens/TitleScreen.q.yml
@@ -182,12 +182,6 @@ properties:
     getter: true
     setter: true
 
-  - name: background
-    type: AllegroFlare::Elements::Backgrounds::Base*
-    init_with: nullptr
-    setter: true
-    getter: true
-
   - name: title_position_x
     type: float
     init_with: 1920 / 2
@@ -621,9 +615,7 @@ functions:
     virtual: true
     override: true
     body: |
-      if (background) background->update();
       update();
-      if (background) background->render();
       render();
       return;
 

--- a/quintessence/AllegroFlare/Screens/Version.q.yml
+++ b/quintessence/AllegroFlare/Screens/Version.q.yml
@@ -70,12 +70,6 @@ properties:
     getter: true
     setter: true
 
-  - name: background
-    type: AllegroFlare::Elements::Backgrounds::Base*
-    init_with: nullptr
-    setter: true
-    getter: true
-
   - name: initialized
     type: bool
     init_with: false
@@ -211,7 +205,6 @@ functions:
     override: true
     guards: [ initialized ]
     body: |
-      if (background) background->activate();
       //emit_event_to_update_input_hints_bar();
       //emit_show_and_size_input_hints_bar_event();
       return;
@@ -222,7 +215,6 @@ functions:
     override: true
     guards: [ initialized ]
     body: |
-      if (background) background->deactivate();
       //emit_hide_and_restore_size_input_hints_bar_event();
       return;
 
@@ -244,9 +236,7 @@ functions:
     override: true
     guards: [ initialized ]
     body: |
-      if (background) background->update();
       update();
-      if (background) background->render();
       render();
       return;
 

--- a/src/AllegroFlare/ScreenManagers/Dictionary.cpp
+++ b/src/AllegroFlare/ScreenManagers/Dictionary.cpp
@@ -108,7 +108,7 @@ int Dictionary::deactivate_all_screens_not_of(const std::string& screen_identifi
          num_screens_deactivated++;
          if (screen.second.screen)
          {
-            screen.second.screen->on_deactivate();
+            screen.second.screen->managed_on_deactivate();
             // TODO: emit ALLEGRO_FLARE_EVENT_SCREEN_DEACTIVATED
          }
          else
@@ -279,7 +279,7 @@ bool Dictionary::activate(std::string identifier)
          screen.second.active = true;
          if (screen.second.screen)
          {
-            screen.second.screen->on_activate();
+            screen.second.screen->managed_on_activate();
             // TODO: emit ALLEGRO_FLARE_EVENT_SCREEN_ACTIVATED
             // TODO: emit ALLEGRO_FLARE_EVENT_SCREEN_DEACTIVATED
          }

--- a/src/AllegroFlare/Screens/Achievements.cpp
+++ b/src/AllegroFlare/Screens/Achievements.cpp
@@ -15,7 +15,7 @@ namespace Screens
 {
 
 
-Achievements::Achievements(AllegroFlare::FontBin* font_bin, AllegroFlare::EventEmitter* event_emitter, AllegroFlare::Achievements* achievements, float scrollbar_dest_position, std::string game_event_name_to_emit_on_exit, AllegroFlare::Elements::Backgrounds::Base* background)
+Achievements::Achievements(AllegroFlare::FontBin* font_bin, AllegroFlare::EventEmitter* event_emitter, AllegroFlare::Achievements* achievements, float scrollbar_dest_position, std::string game_event_name_to_emit_on_exit)
    : AllegroFlare::Screens::Base("Achievements")
    , font_bin(font_bin)
    , event_emitter(event_emitter)
@@ -25,7 +25,6 @@ Achievements::Achievements(AllegroFlare::FontBin* font_bin, AllegroFlare::EventE
    , on_exit_callback_func()
    , on_exit_callback_func_user_data(nullptr)
    , game_event_name_to_emit_on_exit(game_event_name_to_emit_on_exit)
-   , background(background)
    , initialized(false)
 {
 }
@@ -60,12 +59,6 @@ void Achievements::set_game_event_name_to_emit_on_exit(std::string game_event_na
 }
 
 
-void Achievements::set_background(AllegroFlare::Elements::Backgrounds::Base* background)
-{
-   this->background = background;
-}
-
-
 std::function<void(AllegroFlare::Screens::Achievements*, void*)> Achievements::get_on_exit_callback_func() const
 {
    return on_exit_callback_func;
@@ -81,12 +74,6 @@ void* Achievements::get_on_exit_callback_func_user_data() const
 std::string Achievements::get_game_event_name_to_emit_on_exit() const
 {
    return game_event_name_to_emit_on_exit;
-}
-
-
-AllegroFlare::Elements::Backgrounds::Base* Achievements::get_background() const
-{
-   return background;
 }
 
 
@@ -141,7 +128,6 @@ void Achievements::on_activate()
       std::cerr << "\033[1;31m" << error_message.str() << " An exception will be thrown to halt the program.\033[0m" << std::endl;
       throw std::runtime_error("Achievements::on_activate: error: guard \"initialized\" not met");
    }
-   if (background) background->activate();
    // refresh the achievements from the actual list of achievements
    refresh_achievements_list();
 
@@ -164,7 +150,6 @@ void Achievements::on_deactivate()
       std::cerr << "\033[1;31m" << error_message.str() << " An exception will be thrown to halt the program.\033[0m" << std::endl;
       throw std::runtime_error("Achievements::on_deactivate: error: guard \"initialized\" not met");
    }
-   if (background) background->deactivate();
    // emit events to show and set the input hints
    // TODO: add ALLEGRO_FLARE_EVENT_CLEAR_INPUT_HINTS_BAR
    event_emitter->emit_set_input_hints_bar_event({});
@@ -246,7 +231,6 @@ void Achievements::update()
       std::cerr << "\033[1;31m" << error_message.str() << " An exception will be thrown to halt the program.\033[0m" << std::endl;
       throw std::runtime_error("Achievements::update: error: guard \"initialized\" not met");
    }
-   if (background) background->update();
    float scrollbar_position = achievements_list.get_scrollbar_position();
    if (scrollbar_position != scrollbar_dest_position)
    {
@@ -339,7 +323,6 @@ void Achievements::render()
       std::cerr << "\033[1;31m" << error_message.str() << " An exception will be thrown to halt the program.\033[0m" << std::endl;
       throw std::runtime_error("Achievements::render: error: guard \"initialized\" not met");
    }
-   if (background) background->render();
    achievements_list.render();
    return;
 }

--- a/src/AllegroFlare/Screens/Base.cpp
+++ b/src/AllegroFlare/Screens/Base.cpp
@@ -16,6 +16,8 @@ namespace Screens
 
 Base::Base(std::string type)
    : type(type)
+   , background(nullptr)
+   , foreground(nullptr)
 {
 }
 
@@ -25,10 +27,10 @@ Base::~Base()
 }
 
 
-void Base::set_type(std::string type)
-{
-   this->type = type;
-}
+//void Base::set_type(std::string type)
+//{
+   //this->type = type;
+//}
 
 
 std::string Base::get_type()
@@ -43,9 +45,43 @@ bool Base::is_type(std::string possible_type)
 }
 
 
+void Base::set_background(AllegroFlare::Elements::Backgrounds::Base *background)
+{
+   this->background = background;
+}
+
+
+void Base::set_foreground(AllegroFlare::Elements::Backgrounds::Base *foreground)
+{
+   this->foreground = foreground;
+}
+
+
+AllegroFlare::Elements::Backgrounds::Base *Base::get_background()
+{
+   return background;
+}
+
+
+AllegroFlare::Elements::Backgrounds::Base *Base::get_foreground()
+{
+   return foreground;
+}
+
+
 void Base::managed_primary_timer_func()
 {
+   if (background)
+   {
+      background->update();
+      background->render();
+   }
    primary_timer_func();
+   if (foreground)
+   {
+      foreground->update();
+      foreground->render();
+   }
 }
 
 

--- a/src/AllegroFlare/Screens/Base.cpp
+++ b/src/AllegroFlare/Screens/Base.cpp
@@ -85,7 +85,25 @@ void Base::managed_primary_timer_func()
 }
 
 
+void Base::managed_on_activate()
+{
+   if (background) background->activate();
+   on_activate();
+   if (foreground) foreground->activate();
+}
+
+
+void Base::managed_on_deactivate()
+{
+   if (background) background->deactivate();
+   on_deactivate();
+   if (foreground) foreground->deactivate();
+}
+
+
 void Base::on_activate() {}
+
+
 void Base::on_deactivate() {}
 void Base::on_event(ALLEGRO_EVENT *ev) {}
 void Base::primary_timer_func() {}

--- a/src/AllegroFlare/Screens/CharacterNameInput.cpp
+++ b/src/AllegroFlare/Screens/CharacterNameInput.cpp
@@ -14,12 +14,11 @@ namespace Screens
 {
 
 
-CharacterNameInput::CharacterNameInput(AllegroFlare::EventEmitter* event_emitter, AllegroFlare::FontBin* font_bin, AllegroFlare::SoftwareKeyboard::SoftwareKeyboard software_keyboard, AllegroFlare::Elements::Backgrounds::Base* background)
+CharacterNameInput::CharacterNameInput(AllegroFlare::EventEmitter* event_emitter, AllegroFlare::FontBin* font_bin, AllegroFlare::SoftwareKeyboard::SoftwareKeyboard software_keyboard)
    : AllegroFlare::Screens::Base("CharacterNameInput")
    , event_emitter(event_emitter)
    , font_bin(font_bin)
    , software_keyboard(software_keyboard)
-   , background(background)
    , mode(MODE_USING_VIRTUAL_CONTROLS)
    , initialized(false)
 {
@@ -40,18 +39,6 @@ void CharacterNameInput::set_event_emitter(AllegroFlare::EventEmitter* event_emi
 void CharacterNameInput::set_font_bin(AllegroFlare::FontBin* font_bin)
 {
    this->font_bin = font_bin;
-}
-
-
-void CharacterNameInput::set_background(AllegroFlare::Elements::Backgrounds::Base* background)
-{
-   this->background = background;
-}
-
-
-AllegroFlare::Elements::Backgrounds::Base* CharacterNameInput::get_background() const
-{
-   return background;
 }
 
 
@@ -99,7 +86,6 @@ void CharacterNameInput::on_activate()
       std::cerr << "\033[1;31m" << error_message.str() << " An exception will be thrown to halt the program.\033[0m" << std::endl;
       throw std::runtime_error("CharacterNameInput::on_activate: error: guard \"initialized\" not met");
    }
-   if (background) background->activate();
    software_keyboard.reset();
    return;
 }
@@ -113,7 +99,6 @@ void CharacterNameInput::on_deactivate()
       std::cerr << "\033[1;31m" << error_message.str() << " An exception will be thrown to halt the program.\033[0m" << std::endl;
       throw std::runtime_error("CharacterNameInput::on_deactivate: error: guard \"initialized\" not met");
    }
-   if (background) background->deactivate();
    return;
 }
 
@@ -126,8 +111,6 @@ void CharacterNameInput::primary_timer_func()
       std::cerr << "\033[1;31m" << error_message.str() << " An exception will be thrown to halt the program.\033[0m" << std::endl;
       throw std::runtime_error("CharacterNameInput::primary_timer_func: error: guard \"initialized\" not met");
    }
-   if (background) background->update();
-   if (background) background->render();
    render();
    return;
 }

--- a/src/AllegroFlare/Screens/GameOverScreen.cpp
+++ b/src/AllegroFlare/Screens/GameOverScreen.cpp
@@ -28,7 +28,6 @@ GameOverScreen::GameOverScreen(AllegroFlare::EventEmitter* event_emitter, Allegr
    , menu_options(DEFAULT_MENU_OPTIONS)
    , on_menu_choice_callback_func()
    , on_menu_choice_callback_func_user_data(nullptr)
-   , background(nullptr)
    , cursor_position(0)
    , title_font_name(title_font_name)
    , title_font_size(title_font_size)
@@ -74,12 +73,6 @@ void GameOverScreen::set_on_menu_choice_callback_func_user_data(void* on_menu_ch
 }
 
 
-void GameOverScreen::set_background(AllegroFlare::Elements::Backgrounds::Base* background)
-{
-   this->background = background;
-}
-
-
 void GameOverScreen::set_title_font_name(std::string title_font_name)
 {
    this->title_font_name = title_font_name;
@@ -113,12 +106,6 @@ std::function<void(AllegroFlare::Screens::GameOverScreen*, void*)> GameOverScree
 void* GameOverScreen::get_on_menu_choice_callback_func_user_data() const
 {
    return on_menu_choice_callback_func_user_data;
-}
-
-
-AllegroFlare::Elements::Backgrounds::Base* GameOverScreen::get_background() const
-{
-   return background;
 }
 
 
@@ -178,13 +165,11 @@ void GameOverScreen::initialize()
 
 void GameOverScreen::on_activate()
 {
-   if (background) background->activate();
    return;
 }
 
 void GameOverScreen::on_deactivate()
 {
-   if (background) background->deactivate();
    return;
 }
 
@@ -220,8 +205,6 @@ void GameOverScreen::select_menu_option()
 
 void GameOverScreen::primary_timer_func()
 {
-   if (background) background->update();
-   if (background) background->render();
    render();
    return;
 }

--- a/src/AllegroFlare/Screens/GameWonScreen.cpp
+++ b/src/AllegroFlare/Screens/GameWonScreen.cpp
@@ -19,14 +19,13 @@ std::string GameWonScreen::DEFAULT_TITLE_TEXT = "Y   O   U      W   I   N";
 std::string GameWonScreen::DEFAULT_INSTRUCTION_TEXT = "Press any button";
 
 
-GameWonScreen::GameWonScreen(AllegroFlare::EventEmitter* event_emitter, AllegroFlare::FontBin* font_bin, std::string title_text, AllegroFlare::Elements::Backgrounds::Base* background, std::string title_font_name, int title_font_size, std::string instruction_text, std::string instruction_font_name, int instruction_font_size, std::string game_event_name_to_emit_on_submission)
+GameWonScreen::GameWonScreen(AllegroFlare::EventEmitter* event_emitter, AllegroFlare::FontBin* font_bin, std::string title_text, std::string title_font_name, int title_font_size, std::string instruction_text, std::string instruction_font_name, int instruction_font_size, std::string game_event_name_to_emit_on_submission)
    : AllegroFlare::Screens::Base("GameWonScreen")
    , event_emitter(event_emitter)
    , font_bin(font_bin)
    , title_text(title_text)
    , on_submit_callback_func()
    , on_submit_callback_func_user_data(nullptr)
-   , background(background)
    , title_font_name(title_font_name)
    , title_font_size(title_font_size)
    , instruction_text(instruction_text)
@@ -69,12 +68,6 @@ void GameWonScreen::set_on_submit_callback_func(std::function<void(AllegroFlare:
 void GameWonScreen::set_on_submit_callback_func_user_data(void* on_submit_callback_func_user_data)
 {
    this->on_submit_callback_func_user_data = on_submit_callback_func_user_data;
-}
-
-
-void GameWonScreen::set_background(AllegroFlare::Elements::Backgrounds::Base* background)
-{
-   this->background = background;
 }
 
 
@@ -126,12 +119,6 @@ void* GameWonScreen::get_on_submit_callback_func_user_data() const
 }
 
 
-AllegroFlare::Elements::Backgrounds::Base* GameWonScreen::get_background() const
-{
-   return background;
-}
-
-
 std::string GameWonScreen::get_title_font_name() const
 {
    return title_font_name;
@@ -164,20 +151,16 @@ std::string GameWonScreen::get_game_event_name_to_emit_on_submission() const
 
 void GameWonScreen::on_activate()
 {
-   if (background) background->activate();
    return;
 }
 
 void GameWonScreen::on_deactivate()
 {
-   if (background) background->deactivate();
    return;
 }
 
 void GameWonScreen::primary_timer_func()
 {
-   if (background) background->update();
-   if (background) background->render();
    render();
    return;
 }

--- a/src/AllegroFlare/Screens/InputDeviceConfiguration.cpp
+++ b/src/AllegroFlare/Screens/InputDeviceConfiguration.cpp
@@ -27,7 +27,6 @@ InputDeviceConfiguration::InputDeviceConfiguration(AllegroFlare::EventEmitter* e
    , input_devices_list(input_devices_list)
    , input_devices_list_element()
    , input_device_configuration_element()
-   , background(nullptr)
    , initialized(false)
 {
 }
@@ -62,12 +61,6 @@ void InputDeviceConfiguration::set_on_exit_callback_func_user_data(void* on_exit
 }
 
 
-void InputDeviceConfiguration::set_background(AllegroFlare::Elements::Backgrounds::Base* background)
-{
-   this->background = background;
-}
-
-
 std::size_t InputDeviceConfiguration::get_surface_width() const
 {
    return surface_width;
@@ -89,12 +82,6 @@ std::function<void(AllegroFlare::Screens::InputDeviceConfiguration*, void*)> Inp
 void* InputDeviceConfiguration::get_on_exit_callback_func_user_data() const
 {
    return on_exit_callback_func_user_data;
-}
-
-
-AllegroFlare::Elements::Backgrounds::Base* InputDeviceConfiguration::get_background() const
-{
-   return background;
 }
 
 
@@ -231,7 +218,6 @@ void InputDeviceConfiguration::on_activate()
       std::cerr << "\033[1;31m" << error_message.str() << " An exception will be thrown to halt the program.\033[0m" << std::endl;
       throw std::runtime_error("InputDeviceConfiguration::on_activate: error: guard \"initialized\" not met");
    }
-   if (background) background->activate();
    //emit_event_to_update_input_hints_bar();
    //emit_show_and_size_input_hints_bar_event();
    return;
@@ -246,7 +232,6 @@ void InputDeviceConfiguration::on_deactivate()
       std::cerr << "\033[1;31m" << error_message.str() << " An exception will be thrown to halt the program.\033[0m" << std::endl;
       throw std::runtime_error("InputDeviceConfiguration::on_deactivate: error: guard \"initialized\" not met");
    }
-   if (background) background->deactivate();
    //emit_hide_and_restore_size_input_hints_bar_event();
    return;
 }
@@ -272,9 +257,7 @@ void InputDeviceConfiguration::primary_timer_func()
       std::cerr << "\033[1;31m" << error_message.str() << " An exception will be thrown to halt the program.\033[0m" << std::endl;
       throw std::runtime_error("InputDeviceConfiguration::primary_timer_func: error: guard \"initialized\" not met");
    }
-   if (background) background->update();
    update();
-   if (background) background->render();
    render();
    return;
 }

--- a/src/AllegroFlare/Screens/LevelSelectScreen.cpp
+++ b/src/AllegroFlare/Screens/LevelSelectScreen.cpp
@@ -23,7 +23,6 @@ LevelSelectScreen::LevelSelectScreen(AllegroFlare::EventEmitter* event_emitter, 
    , level_select_element()
    , on_menu_choice_callback_func()
    , on_menu_choice_callback_func_user_data(nullptr)
-   , background(nullptr)
    , initialized(false)
 {
 }
@@ -46,12 +45,6 @@ void LevelSelectScreen::set_on_menu_choice_callback_func_user_data(void* on_menu
 }
 
 
-void LevelSelectScreen::set_background(AllegroFlare::Elements::Backgrounds::Base* background)
-{
-   this->background = background;
-}
-
-
 std::function<void(AllegroFlare::Screens::LevelSelectScreen*, void*)> LevelSelectScreen::get_on_menu_choice_callback_func() const
 {
    return on_menu_choice_callback_func;
@@ -61,12 +54,6 @@ std::function<void(AllegroFlare::Screens::LevelSelectScreen*, void*)> LevelSelec
 void* LevelSelectScreen::get_on_menu_choice_callback_func_user_data() const
 {
    return on_menu_choice_callback_func_user_data;
-}
-
-
-AllegroFlare::Elements::Backgrounds::Base* LevelSelectScreen::get_background() const
-{
-   return background;
 }
 
 
@@ -193,7 +180,6 @@ void LevelSelectScreen::on_activate()
       std::cerr << "\033[1;31m" << error_message.str() << " An exception will be thrown to halt the program.\033[0m" << std::endl;
       throw std::runtime_error("LevelSelectScreen::on_activate: error: guard \"initialized\" not met");
    }
-   if (background) background->activate();
    //emit_event_to_update_input_hints_bar();
    //emit_show_and_size_input_hints_bar_event();
    return;
@@ -208,7 +194,6 @@ void LevelSelectScreen::on_deactivate()
       std::cerr << "\033[1;31m" << error_message.str() << " An exception will be thrown to halt the program.\033[0m" << std::endl;
       throw std::runtime_error("LevelSelectScreen::on_deactivate: error: guard \"initialized\" not met");
    }
-   if (background) background->deactivate();
    //emit_hide_and_restore_size_input_hints_bar_event();
    return;
 }
@@ -272,9 +257,7 @@ void LevelSelectScreen::primary_timer_func()
       std::cerr << "\033[1;31m" << error_message.str() << " An exception will be thrown to halt the program.\033[0m" << std::endl;
       throw std::runtime_error("LevelSelectScreen::primary_timer_func: error: guard \"initialized\" not met");
    }
-   if (background) background->update();
    update();
-   if (background) background->render();
    render();
    return;
 }

--- a/src/AllegroFlare/Screens/PauseScreen.cpp
+++ b/src/AllegroFlare/Screens/PauseScreen.cpp
@@ -26,7 +26,6 @@ PauseScreen::PauseScreen(AllegroFlare::EventEmitter* event_emitter, AllegroFlare
    , footer_text(footer_text)
    , on_menu_choice_callback_func()
    , on_menu_choice_callback_func_user_data(nullptr)
-   , background(nullptr)
    , title_bitmap_name(title_bitmap_name)
    , font_name(font_name)
    , title_text_color(title_text_color)
@@ -88,12 +87,6 @@ void PauseScreen::set_on_menu_choice_callback_func(std::function<void(AllegroFla
 void PauseScreen::set_on_menu_choice_callback_func_user_data(void* on_menu_choice_callback_func_user_data)
 {
    this->on_menu_choice_callback_func_user_data = on_menu_choice_callback_func_user_data;
-}
-
-
-void PauseScreen::set_background(AllegroFlare::Elements::Backgrounds::Base* background)
-{
-   this->background = background;
 }
 
 
@@ -187,12 +180,6 @@ void* PauseScreen::get_on_menu_choice_callback_func_user_data() const
 }
 
 
-AllegroFlare::Elements::Backgrounds::Base* PauseScreen::get_background() const
-{
-   return background;
-}
-
-
 std::string PauseScreen::get_title_bitmap_name() const
 {
    return title_bitmap_name;
@@ -273,14 +260,12 @@ float PauseScreen::get_title_menu_gutter() const
 
 void PauseScreen::on_activate()
 {
-   if (background) background->activate();
    cursor_position = 0;
    return;
 }
 
 void PauseScreen::on_deactivate()
 {
-   if (background) background->deactivate();
    return;
 }
 
@@ -343,8 +328,6 @@ void PauseScreen::select_menu_option()
 
 void PauseScreen::primary_timer_func()
 {
-   if (background) background->update();
-   if (background) background->render();
    render();
    return;
 }

--- a/src/AllegroFlare/Screens/RollingCredits.cpp
+++ b/src/AllegroFlare/Screens/RollingCredits.cpp
@@ -27,7 +27,6 @@ RollingCredits::RollingCredits(AllegroFlare::FontBin* font_bin, AllegroFlare::Ev
    , cached_calculated_height(0.0f)
    , game_event_name_to_emit_after_completing(game_event_name_to_emit_after_completing)
    , route_event_to_emit_after_completing(route_event_to_emit_after_completing)
-   , background(nullptr)
    , scroll_is_past_end(false)
    , initialized(false)
 {
@@ -93,12 +92,6 @@ void RollingCredits::set_route_event_to_emit_after_completing(uint32_t route_eve
 }
 
 
-void RollingCredits::set_background(AllegroFlare::Elements::Backgrounds::Base* background)
-{
-   this->background = background;
-}
-
-
 AllegroFlare::Elements::RollingCredits::RollingCredits RollingCredits::get_rolling_credits_component() const
 {
    return rolling_credits_component;
@@ -159,12 +152,6 @@ uint32_t RollingCredits::get_route_event_to_emit_after_completing() const
 }
 
 
-AllegroFlare::Elements::Backgrounds::Base* RollingCredits::get_background() const
-{
-   return background;
-}
-
-
 bool RollingCredits::get_scroll_is_past_end() const
 {
    return scroll_is_past_end;
@@ -198,7 +185,6 @@ void RollingCredits::on_activate()
       std::cerr << "\033[1;31m" << error_message.str() << " An exception will be thrown to halt the program.\033[0m" << std::endl;
       throw std::runtime_error("RollingCredits::on_activate: error: guard \"initialized\" not met");
    }
-   if (background) background->activate();
    y_offset = -surface_height;
    scroll_is_past_end = false;
    return;
@@ -213,7 +199,6 @@ void RollingCredits::on_deactivate()
       std::cerr << "\033[1;31m" << error_message.str() << " An exception will be thrown to halt the program.\033[0m" << std::endl;
       throw std::runtime_error("RollingCredits::on_deactivate: error: guard \"initialized\" not met");
    }
-   if (background) background->deactivate();
    return;
 }
 
@@ -362,9 +347,7 @@ void RollingCredits::primary_timer_func()
       std::cerr << "\033[1;31m" << error_message.str() << " An exception will be thrown to halt the program.\033[0m" << std::endl;
       throw std::runtime_error("RollingCredits::primary_timer_func: error: guard \"al_is_font_addon_initialized()\" not met");
    }
-   if (background) background->update();
    update();
-   if (background) background->render();
    render();
    return;
 }

--- a/src/AllegroFlare/Screens/Storyboard.cpp
+++ b/src/AllegroFlare/Screens/Storyboard.cpp
@@ -25,7 +25,6 @@ Storyboard::Storyboard(AllegroFlare::EventEmitter* event_emitter, AllegroFlare::
    , auto_advance(false)
    , game_event_name_to_emit_after_completing(game_event_name_to_emit_after_completing)
    , route_event_to_emit_after_completing(route_event_to_emit_after_completing)
-   , background(nullptr)
    , initialized(false)
 {
 }
@@ -78,12 +77,6 @@ void Storyboard::set_route_event_to_emit_after_completing(uint32_t route_event_t
 }
 
 
-void Storyboard::set_background(AllegroFlare::Elements::Backgrounds::Base* background)
-{
-   this->background = background;
-}
-
-
 std::function<void(AllegroFlare::Screens::Storyboard*, void*)> Storyboard::get_on_finished_callback_func() const
 {
    return on_finished_callback_func;
@@ -111,12 +104,6 @@ std::string Storyboard::get_game_event_name_to_emit_after_completing() const
 uint32_t Storyboard::get_route_event_to_emit_after_completing() const
 {
    return route_event_to_emit_after_completing;
-}
-
-
-AllegroFlare::Elements::Backgrounds::Base* Storyboard::get_background() const
-{
-   return background;
 }
 
 
@@ -149,7 +136,6 @@ void Storyboard::on_activate()
       std::cerr << "\033[1;31m" << error_message.str() << " An exception will be thrown to halt the program.\033[0m" << std::endl;
       throw std::runtime_error("Storyboard::on_activate: error: guard \"initialized\" not met");
    }
-   if (background) background->activate();
    storyboard_element.reset();
    if (storyboard_element.infer_has_no_pages())
    {
@@ -172,7 +158,6 @@ void Storyboard::on_deactivate()
       std::cerr << "\033[1;31m" << error_message.str() << " An exception will be thrown to halt the program.\033[0m" << std::endl;
       throw std::runtime_error("Storyboard::on_deactivate: error: guard \"initialized\" not met");
    }
-   if (background) background->deactivate();
    return;
 }
 
@@ -185,12 +170,10 @@ void Storyboard::primary_timer_func()
       std::cerr << "\033[1;31m" << error_message.str() << " An exception will be thrown to halt the program.\033[0m" << std::endl;
       throw std::runtime_error("Storyboard::primary_timer_func: error: guard \"initialized\" not met");
    }
-   if (background) background->update();
 
    storyboard_element.update();
    if (storyboard_element.get_can_advance_to_next_page() && auto_advance) advance();
 
-   if (background) background->render();
    storyboard_element.render();
    return;
 }

--- a/src/AllegroFlare/Screens/TitleScreen.cpp
+++ b/src/AllegroFlare/Screens/TitleScreen.cpp
@@ -50,7 +50,6 @@ TitleScreen::TitleScreen(AllegroFlare::EventEmitter* event_emitter, AllegroFlare
    , on_menu_choice_callback_func_user_data(nullptr)
    , on_finished_callback_func()
    , on_finished_callback_func_user_data(nullptr)
-   , background(nullptr)
    , title_position_x(1920 / 2)
    , title_position_y((1080 / 24 * 9))
    , menu_position_x(1920 / 2)
@@ -227,12 +226,6 @@ void TitleScreen::set_on_finished_callback_func(std::function<void(AllegroFlare:
 void TitleScreen::set_on_finished_callback_func_user_data(void* on_finished_callback_func_user_data)
 {
    this->on_finished_callback_func_user_data = on_finished_callback_func_user_data;
-}
-
-
-void TitleScreen::set_background(AllegroFlare::Elements::Backgrounds::Base* background)
-{
-   this->background = background;
 }
 
 
@@ -431,12 +424,6 @@ std::function<void(AllegroFlare::Screens::TitleScreen*, void*)> TitleScreen::get
 void* TitleScreen::get_on_finished_callback_func_user_data() const
 {
    return on_finished_callback_func_user_data;
-}
-
-
-AllegroFlare::Elements::Backgrounds::Base* TitleScreen::get_background() const
-{
-   return background;
 }
 
 
@@ -751,9 +738,7 @@ bool TitleScreen::is_state(uint32_t possible_state)
 
 void TitleScreen::primary_timer_func()
 {
-   if (background) background->update();
    update();
-   if (background) background->render();
    render();
    return;
 }

--- a/src/AllegroFlare/Screens/Version.cpp
+++ b/src/AllegroFlare/Screens/Version.cpp
@@ -31,7 +31,6 @@ Version::Version(AllegroFlare::EventEmitter* event_emitter, AllegroFlare::Bitmap
    , on_exit_callback_func()
    , on_exit_callback_func_user_data(nullptr)
    , game_event_name_to_emit_on_exit(DEFAULT_EVENT_NAME_ON_EXIT)
-   , background(nullptr)
    , initialized(false)
 {
 }
@@ -72,12 +71,6 @@ void Version::set_game_event_name_to_emit_on_exit(std::string game_event_name_to
 }
 
 
-void Version::set_background(AllegroFlare::Elements::Backgrounds::Base* background)
-{
-   this->background = background;
-}
-
-
 float Version::get_surface_width() const
 {
    return surface_width;
@@ -111,12 +104,6 @@ void* Version::get_on_exit_callback_func_user_data() const
 std::string Version::get_game_event_name_to_emit_on_exit() const
 {
    return game_event_name_to_emit_on_exit;
-}
-
-
-AllegroFlare::Elements::Backgrounds::Base* Version::get_background() const
-{
-   return background;
 }
 
 
@@ -289,7 +276,6 @@ void Version::on_activate()
       std::cerr << "\033[1;31m" << error_message.str() << " An exception will be thrown to halt the program.\033[0m" << std::endl;
       throw std::runtime_error("Version::on_activate: error: guard \"initialized\" not met");
    }
-   if (background) background->activate();
    //emit_event_to_update_input_hints_bar();
    //emit_show_and_size_input_hints_bar_event();
    return;
@@ -304,7 +290,6 @@ void Version::on_deactivate()
       std::cerr << "\033[1;31m" << error_message.str() << " An exception will be thrown to halt the program.\033[0m" << std::endl;
       throw std::runtime_error("Version::on_deactivate: error: guard \"initialized\" not met");
    }
-   if (background) background->deactivate();
    //emit_hide_and_restore_size_input_hints_bar_event();
    return;
 }
@@ -330,9 +315,7 @@ void Version::primary_timer_func()
       std::cerr << "\033[1;31m" << error_message.str() << " An exception will be thrown to halt the program.\033[0m" << std::endl;
       throw std::runtime_error("Version::primary_timer_func: error: guard \"initialized\" not met");
    }
-   if (background) background->update();
    update();
-   if (background) background->render();
    render();
    return;
 }


### PR DESCRIPTION
## Add `background` and `foreground`

Each derived Screen class had a `background` and a `foreground`. Recently a shared foreground was considered for FadeToWhite, and doing so would have meant re-implementing the feature across all screens.  This PR moves the `background` into Base, and adds a `foreground` as well (of type `AllegroFlare::Backgrounds::Base*` for now).

(I also considered writing a wrapper class but it would have meant some excess "design" downstream.)

## Remove `ElementID` parent from `Screens/Base`

From a somewhat old design, `Screens/Base` had a parent class of `ElementID`. Within `AllegroFlare`, that parentage was never being used.  Any properties have been much better managed with actual members on the class for a while now. A complete rebuild returned no instance of dependence on the `ElementID` parent with all tests passing.  FadeToWhite was then rebuilt with no issues and all tests passing.

Some things to keep an eye on:
- ✅ FadeToWhite was rebuilt with no issues
- ⚠️ Other downstream projects may rely on the `ElementID` parent, but I would wager there are actually none.
- ⚠️ Other downstream projects may rely on `#include`s that were a part of `ElementID`. An missing symbol for `std::cout` surfaced, so it's possible most dependencies are trivial.